### PR TITLE
Optimize Schwaemm192-192 AEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,65 +79,79 @@ make benchmark
 ### On ARM Cortex-A72
 
 ```bash
-2022-05-25T05:19:03+00:00
+2022-05-27T06:22:02+00:00
 Running ./bench/a.out
 Run on (16 X 166.66 MHz CPU s)
 CPU Caches:
   L1 Data 32 KiB (x16)
   L1 Instruction 48 KiB (x16)
   L2 Unified 2048 KiB (x4)
-Load Average: 0.15, 0.03, 0.01
+Load Average: 0.62, 0.34, 0.13
 ------------------------------------------------------------------------------------------
 Benchmark                                Time             CPU   Iterations UserCounters...
 ------------------------------------------------------------------------------------------
-esch256_hash/64                        881 ns          881 ns       794001 bytes_per_second=69.2729M/s
-esch256_hash/128                      1513 ns         1513 ns       462583 bytes_per_second=80.6699M/s
-esch256_hash/256                      2763 ns         2763 ns       253369 bytes_per_second=88.3682M/s
-esch256_hash/512                      5262 ns         5262 ns       133024 bytes_per_second=92.7974M/s
-esch256_hash/1024                    10261 ns        10260 ns        68222 bytes_per_second=95.179M/s
-esch256_hash/2048                    20257 ns        20257 ns        34557 bytes_per_second=96.4195M/s
-esch256_hash/4096                    40250 ns        40250 ns        17391 bytes_per_second=97.049M/s
-esch384_hash/64                       2622 ns         2622 ns       266982 bytes_per_second=23.2801M/s
-esch384_hash/128                      4208 ns         4208 ns       166389 bytes_per_second=29.0099M/s
-esch384_hash/256                      7387 ns         7387 ns        94752 bytes_per_second=33.0496M/s
-esch384_hash/512                     13751 ns        13751 ns        50907 bytes_per_second=35.5098M/s
-esch384_hash/1024                    26476 ns        26476 ns        26438 bytes_per_second=36.8848M/s
-esch384_hash/2048                    51927 ns        51927 ns        13478 bytes_per_second=37.6129M/s
-esch384_hash/4096                   102833 ns       102832 ns         6807 bytes_per_second=37.9868M/s
-schwaemm256_128_encrypt/64/32         1217 ns         1217 ns       575040 bytes_per_second=75.2128M/s
-schwaemm256_128_decrypt/64/32         1211 ns         1211 ns       578018 bytes_per_second=75.6004M/s
-schwaemm256_128_encrypt/128/32        1667 ns         1667 ns       419937 bytes_per_second=91.5401M/s
-schwaemm256_128_decrypt/128/32        1659 ns         1659 ns       421998 bytes_per_second=91.9782M/s
-schwaemm256_128_encrypt/256/32        2574 ns         2574 ns       271968 bytes_per_second=106.713M/s
-schwaemm256_128_decrypt/256/32        2564 ns         2564 ns       272961 bytes_per_second=107.105M/s
-schwaemm256_128_encrypt/512/32        4371 ns         4371 ns       160151 bytes_per_second=118.7M/s
-schwaemm256_128_decrypt/512/32        4357 ns         4357 ns       160657 bytes_per_second=119.071M/s
-schwaemm256_128_encrypt/1024/32       7965 ns         7965 ns        87877 bytes_per_second=126.442M/s
-schwaemm256_128_decrypt/1024/32       7942 ns         7942 ns        88125 bytes_per_second=126.797M/s
-schwaemm256_128_encrypt/2048/32      15152 ns        15152 ns        46196 bytes_per_second=130.92M/s
-schwaemm256_128_decrypt/2048/32      15114 ns        15114 ns        46315 bytes_per_second=131.249M/s
-schwaemm256_128_encrypt/4096/32      29529 ns        29528 ns        23699 bytes_per_second=133.323M/s
-schwaemm256_128_decrypt/4096/32      29457 ns        29456 ns        23763 bytes_per_second=133.648M/s
-schwaemm192_192_encrypt/64/32         1602 ns         1602 ns       436916 bytes_per_second=57.1477M/s
-schwaemm192_192_decrypt/64/32         1656 ns         1656 ns       422575 bytes_per_second=55.2699M/s
-schwaemm192_192_encrypt/128/32        2238 ns         2238 ns       312715 bytes_per_second=68.1742M/s
-schwaemm192_192_decrypt/128/32        2284 ns         2284 ns       306416 bytes_per_second=66.8003M/s
-schwaemm192_192_encrypt/256/32        3296 ns         3296 ns       212353 bytes_per_second=83.3223M/s
-schwaemm192_192_decrypt/256/32        3357 ns         3356 ns       208546 bytes_per_second=81.8307M/s
-schwaemm192_192_encrypt/512/32        5606 ns         5606 ns       124843 bytes_per_second=92.5364M/s
-schwaemm192_192_decrypt/512/32        5676 ns         5676 ns       123316 bytes_per_second=91.3981M/s
-schwaemm192_192_encrypt/1024/32      10035 ns        10035 ns        69751 bytes_per_second=100.354M/s
-schwaemm192_192_decrypt/1024/32      10123 ns        10123 ns        69145 bytes_per_second=99.482M/s
-schwaemm192_192_encrypt/2048/32      19094 ns        19094 ns        36679 bytes_per_second=103.889M/s
-schwaemm192_192_decrypt/2048/32      19211 ns        19211 ns        36437 bytes_per_second=103.257M/s
-schwaemm192_192_encrypt/4096/32      37002 ns        37002 ns        18912 bytes_per_second=106.393M/s
-schwaemm192_192_decrypt/4096/32      37192 ns        37191 ns        18822 bytes_per_second=105.852M/s
+esch256_hash/64                        881 ns          881 ns       794284 bytes_per_second=69.2739M/s
+esch256_hash/128                      1513 ns         1513 ns       462592 bytes_per_second=80.6682M/s
+esch256_hash/256                      2763 ns         2763 ns       253373 bytes_per_second=88.3682M/s
+esch256_hash/512                      5262 ns         5262 ns       133016 bytes_per_second=92.796M/s
+esch256_hash/1024                    10260 ns        10260 ns        68226 bytes_per_second=95.1832M/s
+esch256_hash/2048                    20257 ns        20257 ns        34553 bytes_per_second=96.4194M/s
+esch256_hash/4096                    40250 ns        40250 ns        17391 bytes_per_second=97.0508M/s
+esch384_hash/64                       2610 ns         2610 ns       268271 bytes_per_second=23.3881M/s
+esch384_hash/128                      4198 ns         4198 ns       166739 bytes_per_second=29.08M/s
+esch384_hash/256                      7377 ns         7377 ns        94903 bytes_per_second=33.0957M/s
+esch384_hash/512                     13737 ns        13737 ns        50951 bytes_per_second=35.5456M/s
+esch384_hash/1024                    26463 ns        26463 ns        26451 bytes_per_second=36.9027M/s
+esch384_hash/2048                    51917 ns        51915 ns        13483 bytes_per_second=37.6218M/s
+esch384_hash/4096                   102818 ns       102816 ns         6808 bytes_per_second=37.9925M/s
+schwaemm256_128_encrypt/64/32         1219 ns         1219 ns       574333 bytes_per_second=75.1268M/s
+schwaemm256_128_decrypt/64/32         1211 ns         1211 ns       578014 bytes_per_second=75.6014M/s
+schwaemm256_128_encrypt/128/32        1668 ns         1668 ns       419637 bytes_per_second=91.4938M/s
+schwaemm256_128_decrypt/128/32        1659 ns         1659 ns       421978 bytes_per_second=91.9898M/s
+schwaemm256_128_encrypt/256/32        2575 ns         2575 ns       271801 bytes_per_second=106.653M/s
+schwaemm256_128_decrypt/256/32        2564 ns         2564 ns       272968 bytes_per_second=107.112M/s
+schwaemm256_128_encrypt/512/32        4372 ns         4372 ns       160105 bytes_per_second=118.656M/s
+schwaemm256_128_decrypt/512/32        4357 ns         4357 ns       160671 bytes_per_second=119.084M/s
+schwaemm256_128_encrypt/1024/32       7965 ns         7965 ns        87885 bytes_per_second=126.439M/s
+schwaemm256_128_decrypt/1024/32       7943 ns         7942 ns        88133 bytes_per_second=126.799M/s
+schwaemm256_128_encrypt/2048/32      15152 ns        15152 ns        46192 bytes_per_second=130.917M/s
+schwaemm256_128_decrypt/2048/32      15132 ns        15132 ns        46264 bytes_per_second=131.092M/s
+schwaemm256_128_encrypt/4096/32      29529 ns        29528 ns        23706 bytes_per_second=133.323M/s
+schwaemm256_128_decrypt/4096/32      29455 ns        29453 ns        23767 bytes_per_second=133.661M/s
+schwaemm192_192_encrypt/64/32         1492 ns         1492 ns       469185 bytes_per_second=61.3649M/s
+schwaemm192_192_decrypt/64/32         1569 ns         1569 ns       445845 bytes_per_second=58.3449M/s
+schwaemm192_192_encrypt/128/32        2041 ns         2041 ns       342887 bytes_per_second=74.7453M/s
+schwaemm192_192_decrypt/128/32        2142 ns         2142 ns       326846 bytes_per_second=71.2445M/s
+schwaemm192_192_encrypt/256/32        2967 ns         2967 ns       235905 bytes_per_second=92.5608M/s
+schwaemm192_192_decrypt/256/32        3103 ns         3103 ns       225606 bytes_per_second=88.5175M/s
+schwaemm192_192_encrypt/512/32        4986 ns         4986 ns       140390 bytes_per_second=104.047M/s
+schwaemm192_192_decrypt/512/32        5201 ns         5200 ns       134607 bytes_per_second=99.7633M/s
+schwaemm192_192_encrypt/1024/32       8843 ns         8843 ns        79158 bytes_per_second=113.886M/s
+schwaemm192_192_decrypt/1024/32       9204 ns         9204 ns        76046 bytes_per_second=109.419M/s
+schwaemm192_192_encrypt/2048/32      16738 ns        16737 ns        41820 bytes_per_second=118.515M/s
+schwaemm192_192_decrypt/2048/32      17405 ns        17405 ns        40217 bytes_per_second=113.972M/s
+schwaemm192_192_encrypt/4096/32      32348 ns        32348 ns        21640 bytes_per_second=121.702M/s
+schwaemm192_192_decrypt/4096/32      33615 ns        33615 ns        20824 bytes_per_second=117.113M/s
+schwaemm128_128_encrypt/64/32         1127 ns         1127 ns       620904 bytes_per_second=81.2091M/s
+schwaemm128_128_decrypt/64/32         1135 ns         1135 ns       616643 bytes_per_second=80.6505M/s
+schwaemm128_128_encrypt/128/32        1678 ns         1678 ns       417103 bytes_per_second=90.9229M/s
+schwaemm128_128_decrypt/128/32        1669 ns         1669 ns       419498 bytes_per_second=91.446M/s
+schwaemm128_128_encrypt/256/32        2764 ns         2764 ns       253219 bytes_per_second=99.3607M/s
+schwaemm128_128_decrypt/256/32        2720 ns         2720 ns       257373 bytes_per_second=100.983M/s
+schwaemm128_128_encrypt/512/32        4936 ns         4936 ns       141827 bytes_per_second=105.111M/s
+schwaemm128_128_decrypt/512/32        4823 ns         4822 ns       145158 bytes_per_second=107.58M/s
+schwaemm128_128_encrypt/1024/32       9281 ns         9280 ns        75429 bytes_per_second=108.519M/s
+schwaemm128_128_decrypt/1024/32       9027 ns         9027 ns        77545 bytes_per_second=111.562M/s
+schwaemm128_128_encrypt/2048/32      17969 ns        17968 ns        38958 bytes_per_second=110.396M/s
+schwaemm128_128_decrypt/2048/32      17437 ns        17437 ns        40145 bytes_per_second=113.76M/s
+schwaemm128_128_encrypt/4096/32      35346 ns        35345 ns        19806 bytes_per_second=111.382M/s
+schwaemm128_128_decrypt/4096/32      34259 ns        34257 ns        20430 bytes_per_second=114.918M/s
 ```
 
 ### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
 
 ```bash
-2022-05-25T09:14:50+04:00
+2022-05-27T10:11:27+04:00
 Running ./bench/a.out
 Run on (8 X 2400 MHz CPU s)
 CPU Caches:
@@ -145,50 +159,64 @@ CPU Caches:
   L1 Instruction 32 KiB
   L2 Unified 256 KiB (x4)
   L3 Unified 6144 KiB
-Load Average: 2.44, 2.99, 3.07
+Load Average: 2.73, 2.54, 2.55
 ------------------------------------------------------------------------------------------
 Benchmark                                Time             CPU   Iterations UserCounters...
 ------------------------------------------------------------------------------------------
-esch256_hash/64                       1023 ns         1019 ns       686773 bytes_per_second=59.8979M/s
-esch256_hash/128                      1741 ns         1734 ns       398615 bytes_per_second=70.4087M/s
-esch256_hash/256                      3170 ns         3159 ns       215057 bytes_per_second=77.2799M/s
-esch256_hash/512                      6112 ns         6085 ns       113749 bytes_per_second=80.2416M/s
-esch256_hash/1024                    11856 ns        11818 ns        58298 bytes_per_second=82.6355M/s
-esch256_hash/2048                    23527 ns        23417 ns        30085 bytes_per_second=83.4066M/s
-esch256_hash/4096                    46682 ns        46425 ns        14846 bytes_per_second=84.1418M/s
-esch384_hash/64                       1363 ns         1356 ns       514827 bytes_per_second=45.0102M/s
-esch384_hash/128                      2211 ns         2196 ns       321483 bytes_per_second=55.5943M/s
-esch384_hash/256                      3853 ns         3831 ns       181496 bytes_per_second=63.7291M/s
-esch384_hash/512                      7142 ns         7099 ns        97712 bytes_per_second=68.785M/s
-esch384_hash/1024                    13771 ns        13692 ns        50575 bytes_per_second=71.3229M/s
-esch384_hash/2048                    26988 ns        26840 ns        25878 bytes_per_second=72.7681M/s
-esch384_hash/4096                    53581 ns        53324 ns        12812 bytes_per_second=73.2549M/s
-schwaemm256_128_encrypt/64/32         1043 ns         1038 ns       658805 bytes_per_second=88.2212M/s
-schwaemm256_128_decrypt/64/32         1054 ns         1048 ns       664546 bytes_per_second=87.3344M/s
-schwaemm256_128_encrypt/128/32        1428 ns         1420 ns       487859 bytes_per_second=107.432M/s
-schwaemm256_128_decrypt/128/32        1437 ns         1429 ns       484969 bytes_per_second=106.747M/s
-schwaemm256_128_encrypt/256/32        2178 ns         2168 ns       320690 bytes_per_second=126.688M/s
-schwaemm256_128_decrypt/256/32        2190 ns         2179 ns       320839 bytes_per_second=126.025M/s
-schwaemm256_128_encrypt/512/32        3689 ns         3670 ns       189309 bytes_per_second=141.359M/s
-schwaemm256_128_decrypt/512/32        3729 ns         3710 ns       189284 bytes_per_second=139.838M/s
-schwaemm256_128_encrypt/1024/32       6770 ns         6739 ns       103161 bytes_per_second=149.431M/s
-schwaemm256_128_decrypt/1024/32       6788 ns         6756 ns       100805 bytes_per_second=149.074M/s
-schwaemm256_128_encrypt/2048/32      12880 ns        12820 ns        54377 bytes_per_second=154.73M/s
-schwaemm256_128_decrypt/2048/32      12864 ns        12803 ns        54418 bytes_per_second=154.935M/s
-schwaemm256_128_encrypt/4096/32      24974 ns        24854 ns        27887 bytes_per_second=158.399M/s
-schwaemm256_128_decrypt/4096/32      24998 ns        24886 ns        28146 bytes_per_second=158.192M/s
-schwaemm192_192_encrypt/64/32         1407 ns         1401 ns       493834 bytes_per_second=65.3657M/s
-schwaemm192_192_decrypt/64/32         1419 ns         1413 ns       493702 bytes_per_second=64.8064M/s
-schwaemm192_192_encrypt/128/32        1963 ns         1955 ns       356957 bytes_per_second=78.0656M/s
-schwaemm192_192_decrypt/128/32        1979 ns         1969 ns       355279 bytes_per_second=77.4823M/s
-schwaemm192_192_encrypt/256/32        2877 ns         2863 ns       242796 bytes_per_second=95.9467M/s
-schwaemm192_192_decrypt/256/32        2899 ns         2886 ns       240556 bytes_per_second=95.1812M/s
-schwaemm192_192_encrypt/512/32        4945 ns         4922 ns       142583 bytes_per_second=105.396M/s
-schwaemm192_192_decrypt/512/32        4971 ns         4932 ns       135391 bytes_per_second=105.189M/s
-schwaemm192_192_encrypt/1024/32       8963 ns         8908 ns        78629 bytes_per_second=113.057M/s
-schwaemm192_192_decrypt/1024/32       8804 ns         8747 ns        76745 bytes_per_second=115.139M/s
-schwaemm192_192_encrypt/2048/32      16962 ns        16834 ns        41582 bytes_per_second=117.838M/s
-schwaemm192_192_decrypt/2048/32      16906 ns        16807 ns        41489 bytes_per_second=118.027M/s
-schwaemm192_192_encrypt/4096/32      32459 ns        32306 ns        21397 bytes_per_second=121.858M/s
-schwaemm192_192_decrypt/4096/32      33325 ns        33103 ns        21832 bytes_per_second=118.926M/s
+esch256_hash/64                        992 ns          990 ns       692514 bytes_per_second=61.6207M/s
+esch256_hash/128                      1730 ns         1723 ns       411830 bytes_per_second=70.8442M/s
+esch256_hash/256                      3149 ns         3140 ns       225098 bytes_per_second=77.7551M/s
+esch256_hash/512                      6037 ns         6009 ns       117853 bytes_per_second=81.2524M/s
+esch256_hash/1024                    11964 ns        11905 ns        59393 bytes_per_second=82.0304M/s
+esch256_hash/2048                    23526 ns        23415 ns        29018 bytes_per_second=83.4135M/s
+esch256_hash/4096                    46541 ns        46429 ns        14996 bytes_per_second=84.1335M/s
+esch384_hash/64                       1351 ns         1346 ns       521163 bytes_per_second=45.3583M/s
+esch384_hash/128                      2175 ns         2166 ns       322887 bytes_per_second=56.3623M/s
+esch384_hash/256                      3844 ns         3826 ns       183756 bytes_per_second=63.8155M/s
+esch384_hash/512                      7159 ns         7130 ns        97508 bytes_per_second=68.4854M/s
+esch384_hash/1024                    13746 ns        13691 ns        50634 bytes_per_second=71.3282M/s
+esch384_hash/2048                    27007 ns        26899 ns        25732 bytes_per_second=72.6102M/s
+esch384_hash/4096                    53726 ns        53523 ns        13182 bytes_per_second=72.9826M/s
+schwaemm256_128_encrypt/64/32         1047 ns         1042 ns       674992 bytes_per_second=87.8223M/s
+schwaemm256_128_decrypt/64/32         1053 ns         1047 ns       671624 bytes_per_second=87.4128M/s
+schwaemm256_128_encrypt/128/32        1429 ns         1423 ns       492438 bytes_per_second=107.201M/s
+schwaemm256_128_decrypt/128/32        1434 ns         1429 ns       492015 bytes_per_second=106.774M/s
+schwaemm256_128_encrypt/256/32        2179 ns         2170 ns       319895 bytes_per_second=126.544M/s
+schwaemm256_128_decrypt/256/32        2182 ns         2173 ns       320979 bytes_per_second=126.383M/s
+schwaemm256_128_encrypt/512/32        3709 ns         3692 ns       192167 bytes_per_second=140.53M/s
+schwaemm256_128_decrypt/512/32        3694 ns         3677 ns       188569 bytes_per_second=141.109M/s
+schwaemm256_128_encrypt/1024/32       6652 ns         6634 ns       106922 bytes_per_second=151.803M/s
+schwaemm256_128_decrypt/1024/32       6798 ns         6767 ns       104232 bytes_per_second=148.82M/s
+schwaemm256_128_encrypt/2048/32      12874 ns        12809 ns        54467 bytes_per_second=154.859M/s
+schwaemm256_128_decrypt/2048/32      12937 ns        12868 ns        54244 bytes_per_second=154.148M/s
+schwaemm256_128_encrypt/4096/32      25089 ns        24973 ns        27831 bytes_per_second=157.642M/s
+schwaemm256_128_decrypt/4096/32      24963 ns        24865 ns        27931 bytes_per_second=158.326M/s
+schwaemm192_192_encrypt/64/32         1415 ns         1409 ns       497541 bytes_per_second=64.9908M/s
+schwaemm192_192_decrypt/64/32         1412 ns         1407 ns       497293 bytes_per_second=65.078M/s
+schwaemm192_192_encrypt/128/32        1979 ns         1968 ns       355011 bytes_per_second=77.5191M/s
+schwaemm192_192_decrypt/128/32        1986 ns         1977 ns       356256 bytes_per_second=77.1994M/s
+schwaemm192_192_encrypt/256/32        2934 ns         2917 ns       242843 bytes_per_second=94.1428M/s
+schwaemm192_192_decrypt/256/32        2887 ns         2876 ns       242969 bytes_per_second=95.5117M/s
+schwaemm192_192_encrypt/512/32        4964 ns         4941 ns       141144 bytes_per_second=105.009M/s
+schwaemm192_192_decrypt/512/32        4786 ns         4778 ns       138694 bytes_per_second=108.57M/s
+schwaemm192_192_encrypt/1024/32       8753 ns         8741 ns        79798 bytes_per_second=115.219M/s
+schwaemm192_192_decrypt/1024/32       8618 ns         8588 ns        81978 bytes_per_second=117.259M/s
+schwaemm192_192_encrypt/2048/32      16773 ns        16735 ns        41170 bytes_per_second=118.534M/s
+schwaemm192_192_decrypt/2048/32      16523 ns        16436 ns        42380 bytes_per_second=120.691M/s
+schwaemm192_192_encrypt/4096/32      32102 ns        32036 ns        21511 bytes_per_second=122.885M/s
+schwaemm192_192_decrypt/4096/32      31871 ns        31789 ns        21853 bytes_per_second=123.839M/s
+schwaemm128_128_encrypt/64/32          776 ns          771 ns       909800 bytes_per_second=118.793M/s
+schwaemm128_128_decrypt/64/32          715 ns          714 ns       953847 bytes_per_second=128.259M/s
+schwaemm128_128_encrypt/128/32        1033 ns         1032 ns       669856 bytes_per_second=147.916M/s
+schwaemm128_128_decrypt/128/32        1012 ns         1010 ns       698882 bytes_per_second=151.073M/s
+schwaemm128_128_encrypt/256/32        1658 ns         1653 ns       425276 bytes_per_second=166.191M/s
+schwaemm128_128_decrypt/256/32        1636 ns         1629 ns       429206 bytes_per_second=168.563M/s
+schwaemm128_128_encrypt/512/32        2839 ns         2828 ns       248414 bytes_per_second=183.473M/s
+schwaemm128_128_decrypt/512/32        2796 ns         2793 ns       248462 bytes_per_second=185.741M/s
+schwaemm128_128_encrypt/1024/32       5230 ns         5225 ns       130709 bytes_per_second=192.743M/s
+schwaemm128_128_decrypt/1024/32       5152 ns         5144 ns       129735 bytes_per_second=195.77M/s
+schwaemm128_128_encrypt/2048/32      10091 ns        10076 ns        69131 bytes_per_second=196.877M/s
+schwaemm128_128_decrypt/2048/32      10010 ns         9994 ns        69599 bytes_per_second=198.492M/s
+schwaemm128_128_encrypt/4096/32      20217 ns        20034 ns        34591 bytes_per_second=196.506M/s
+schwaemm128_128_decrypt/4096/32      20409 ns        20148 ns        34599 bytes_per_second=195.395M/s
 ```

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -54,5 +54,23 @@ BENCHMARK(schwaemm192_192_decrypt)->Args({ 2048, 32 });
 BENCHMARK(schwaemm192_192_encrypt)->Args({ 4096, 32 });
 BENCHMARK(schwaemm192_192_decrypt)->Args({ 4096, 32 });
 
+// registering Schwaemm128-128 AEAD encrypt/ decrypt routines for benchmark
+//
+// note, associated data size is set to be 32 -bytes for all cases
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 64, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 64, 32 });
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 128, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 128, 32 });
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 256, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 256, 32 });
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 512, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 512, 32 });
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 1024, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 1024, 32 });
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 2048, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 2048, 32 });
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 4096, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 4096, 32 });
+
 // main function to drive execution of benchmark
 BENCHMARK_MAIN();

--- a/include/bench_aead.hpp
+++ b/include/bench_aead.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "schwaemm128_128.hpp"
 #include "schwaemm192_192.hpp"
 #include "schwaemm256_128.hpp"
 #include "utils.hpp"
@@ -189,6 +190,110 @@ schwaemm192_192_decrypt(benchmark::State& state)
 
   for (auto _ : state) {
     using namespace schwaemm192_192;
+    using namespace benchmark;
+
+    DoNotOptimize(decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len));
+    DoNotOptimize(dec);
+  }
+
+  const size_t per_itr_data = dt_len + ct_len;
+  const size_t total_data = per_itr_data * state.iterations();
+
+  state.SetBytesProcessed(static_cast<int64_t>(total_data));
+
+  // deallocate all resources
+  free(text);
+  free(enc);
+  free(dec);
+  free(data);
+  free(key);
+  free(nonce);
+  free(tag);
+}
+
+// Benchmark Schwaemm128-128 Authenticated Encryption Scheme on CPU
+static void
+schwaemm128_128_encrypt(benchmark::State& state)
+{
+  const size_t ct_len = state.range(0);
+  const size_t dt_len = state.range(1);
+  constexpr size_t KNT_LEN = 16;
+
+  // acquire memory resources
+  uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
+  uint8_t* enc = static_cast<uint8_t*>(malloc(ct_len));
+  uint8_t* data = static_cast<uint8_t*>(malloc(dt_len));
+  uint8_t* key = static_cast<uint8_t*>(malloc(KNT_LEN));
+  uint8_t* nonce = static_cast<uint8_t*>(malloc(KNT_LEN));
+  uint8_t* tag = static_cast<uint8_t*>(malloc(KNT_LEN));
+
+  // random plain text bytes
+  random_data(text, ct_len);
+  // random associated data bytes
+  random_data(data, dt_len);
+  // random secret key ( = 128 -bit )
+  random_data(key, KNT_LEN);
+  // random public message nonce ( = 128 -bit )
+  random_data(nonce, KNT_LEN);
+
+  memset(enc, 0, ct_len);
+  memset(tag, 0, KNT_LEN);
+
+  for (auto _ : state) {
+    schwaemm128_128::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
+
+    benchmark::DoNotOptimize(enc);
+    benchmark::DoNotOptimize(tag);
+  }
+
+  const size_t per_itr_data = dt_len + ct_len;
+  const size_t total_data = per_itr_data * state.iterations();
+
+  state.SetBytesProcessed(static_cast<int64_t>(total_data));
+
+  // deallocate all resources
+  free(text);
+  free(enc);
+  free(data);
+  free(key);
+  free(nonce);
+  free(tag);
+}
+
+// Benchmark Schwaemm128-128 Verified Decryption Scheme on CPU
+static void
+schwaemm128_128_decrypt(benchmark::State& state)
+{
+  const size_t ct_len = state.range(0);
+  const size_t dt_len = state.range(1);
+  constexpr size_t KNT_LEN = 16;
+
+  // acquire memory resources
+  uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
+  uint8_t* enc = static_cast<uint8_t*>(malloc(ct_len));
+  uint8_t* dec = static_cast<uint8_t*>(malloc(ct_len));
+  uint8_t* data = static_cast<uint8_t*>(malloc(dt_len));
+  uint8_t* key = static_cast<uint8_t*>(malloc(KNT_LEN));
+  uint8_t* nonce = static_cast<uint8_t*>(malloc(KNT_LEN));
+  uint8_t* tag = static_cast<uint8_t*>(malloc(KNT_LEN));
+
+  // random plain text bytes
+  random_data(text, ct_len);
+  // random associated data bytes
+  random_data(data, dt_len);
+  // random secret key ( = 128 -bit )
+  random_data(key, KNT_LEN);
+  // random public message nonce ( = 128 -bit )
+  random_data(nonce, KNT_LEN);
+
+  memset(enc, 0, ct_len);
+  memset(dec, 0, ct_len);
+  memset(tag, 0, KNT_LEN);
+
+  schwaemm128_128::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
+
+  for (auto _ : state) {
+    using namespace schwaemm128_128;
     using namespace benchmark;
 
     DoNotOptimize(decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len));

--- a/include/schwaemm128_128.hpp
+++ b/include/schwaemm128_128.hpp
@@ -1,0 +1,728 @@
+#pragma once
+#include "sparkle.hpp"
+#include "utils.hpp"
+#include <cstring>
+
+// Schwaemm128-128 Authenticated Encryption with Associated Data ( AEAD ) Scheme
+namespace schwaemm128_128 {
+
+// These many bytes are consumed into permutation state, in every iteration
+constexpr size_t RATE = 16;
+
+// These many 32 -bit words are present in rate width of permutation
+constexpr size_t RATE_W = RATE >> 2;
+
+// To distinguish padded associated data block from non-padded one, this
+// constant is XORed into inner part of permutation state, when processing last
+// associated data block
+constexpr uint32_t CONST_A0 = (0u ^ (1u << 2)) << 24;
+
+// To distinguish non-padded associated data block from padded one, this
+// constant is XORed into inner part of permutation state, when processing last
+// associated data block
+constexpr uint32_t CONST_A1 = (1u ^ (1u << 2)) << 24;
+
+// To distinguish padded plain text block from non-padded one, this constant is
+// XORed into inner part of permutation state, when processing last plain text
+// block
+constexpr uint32_t CONST_M0 = (2u ^ (1u << 2)) << 24;
+
+// To distinguish non-padded plain text block from padded one, this constant is
+// XORed into inner part of permutation state, when processing last plain text
+// block
+constexpr uint32_t CONST_M1 = (3u ^ (1u << 2)) << 24;
+
+// Initialize permutation state by consuming 16 -bytes secret key & 16 -bytes
+// public message nonce, when performing Schwaemm128-128 authenticated
+// encryption/ verified decryption
+//
+// See algorithm 2.17 in Sparkle specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+static inline void
+initialize(uint32_t* const __restrict state,     // 256 -bit permutation state
+           const uint8_t* const __restrict key,  // 16 -bytes secret key
+           const uint8_t* const __restrict nonce // 16 -bytes nonce
+)
+{
+  if constexpr (is_little_endian()) {
+    std::memcpy(state, nonce, RATE);
+    std::memcpy(state + RATE_W, key, RATE);
+  } else {
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+    for (size_t i = 0; i < 4; i++) {
+      const size_t b_off = i << 2;
+
+      const size_t s_idx0 = i;
+      const size_t s_idx1 = RATE_W ^ i;
+
+      state[s_idx0] = (static_cast<uint32_t>(nonce[b_off ^ 3]) << 24) |
+                      (static_cast<uint32_t>(nonce[b_off ^ 2]) << 16) |
+                      (static_cast<uint32_t>(nonce[b_off ^ 1]) << 8) |
+                      (static_cast<uint32_t>(nonce[b_off ^ 0]) << 0);
+
+      state[s_idx1] = (static_cast<uint32_t>(key[b_off ^ 3]) << 24) |
+                      (static_cast<uint32_t>(key[b_off ^ 2]) << 16) |
+                      (static_cast<uint32_t>(key[b_off ^ 1]) << 8) |
+                      (static_cast<uint32_t>(key[b_off ^ 0]) << 0);
+    }
+  }
+
+  sparkle::sparkle<4ul, 10ul>(state);
+}
+
+// FeistelSwap - invoked from combined feedback function `𝜌`,  which is used for
+// differentiating between cipher text & outer part of permutation state
+//
+// See section 2.3.2 of Sparkle specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+//
+// Note, `s` is 128 -bit wide i.e.
+//
+// `s1 || s2 = s` meaning |s1| = |s2| = RATE >> 1 = 64 -bit
+//
+// To be more specific, `s` is actually outer part of permutation state !
+static inline void
+feistel_swap(uint32_t* const __restrict s)
+{
+  std::swap(s[0], s[2]);
+  std::swap(s[1], s[3]);
+
+  s[2] ^= s[0];
+  s[3] ^= s[1];
+}
+
+// Feedback function `𝜌1`, used during Schwaemm128-128 Authenticated Encryption
+//
+// See section 2.3.2 of Sparkle Specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+static inline void
+rho1(uint32_t* const __restrict s,      // 128 -bit
+     const uint32_t* const __restrict d // 128 -bit
+)
+{
+  feistel_swap(s);
+
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
+    s[i] ^= d[i];
+  }
+}
+
+// Feedback function `𝜌2`, used during Schwaemm128-128 Authenticated Encryption
+//
+// See section 2.3.2 of Sparkle Specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+static inline void
+rho2(uint32_t* const __restrict s,      // 128 -bit
+     const uint32_t* const __restrict d // 128 -bit
+)
+{
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
+    s[i] ^= d[i];
+  }
+}
+
+// Inverse Feedback function `𝜌'1`, used during Schwaemm128-128 Verified
+// Decryption
+//
+// See section 2.3.2 of Sparkle Specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+static inline void
+rhoprime1(uint32_t* const __restrict s,      // 128 -bit
+          const uint32_t* const __restrict d // 128 -bit
+)
+{
+  uint32_t s_[RATE_W];
+  std::memcpy(s_, s, RATE);
+
+  feistel_swap(s);
+
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
+    s[i] ^= s_[i] ^ d[i];
+  }
+}
+
+// Inverse Feedback function `𝜌'2`, used during Schwaemm128-128 Authenticated
+// Decryption
+//
+// See section 2.3.2 of Sparkle Specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+static inline void
+rhoprime2(uint32_t* const __restrict s,      // 128 -bit
+          const uint32_t* const __restrict d // 128 -bit
+)
+{
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
+    s[i] ^= d[i];
+  }
+}
+
+// Consumes non-empty associated data into 256 -bit permutation state using
+// algorithm 2.17 of Sparkle specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+static inline void
+process_associated_data(
+  uint32_t* const __restrict state,     // 256 -bit permutation state
+  const uint8_t* const __restrict data, // N (>0) -bytes associated data
+  const size_t d_len                    // len(data) = N -bytes | N > 0
+)
+{
+  uint32_t buffer[RATE_W + 1];
+
+  size_t r_bytes = d_len;
+  while (r_bytes > RATE) {
+    const size_t b_off = d_len - r_bytes;
+
+    if constexpr (is_little_endian()) {
+      std::memcpy(buffer, data + b_off, RATE);
+    } else {
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+      for (size_t i = 0; i < RATE_W; i++) {
+        const size_t i_off = i << 2;
+
+        buffer[i] = (static_cast<uint32_t>(data[b_off + (i_off ^ 3)]) << 24) |
+                    (static_cast<uint32_t>(data[b_off + (i_off ^ 2)]) << 16) |
+                    (static_cast<uint32_t>(data[b_off + (i_off ^ 1)]) << 8) |
+                    (static_cast<uint32_t>(data[b_off + (i_off ^ 0)]) << 0);
+      }
+    }
+
+    rho1(state, buffer);
+
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+    for (size_t i = 0; i < RATE_W; i++) {
+      state[i] ^= state[RATE_W ^ i];
+    }
+
+    sparkle::sparkle<4ul, 7ul>(state);
+
+    r_bytes -= RATE;
+  }
+
+  const size_t b_off = d_len - r_bytes;
+  const size_t rb_full_words = r_bytes >> 2;
+  const size_t rb_rem_bytes = r_bytes & 3ul;
+
+  std::memset(buffer, 0, RATE);
+
+  if constexpr (is_little_endian()) {
+    std::memcpy(buffer, data + b_off, rb_full_words << 2);
+  } else {
+    for (size_t i = 0; i < rb_full_words; i++) {
+      const size_t off = i << 2;
+
+      buffer[i] = (static_cast<uint32_t>(data[b_off + (off ^ 3)]) << 24) |
+                  (static_cast<uint32_t>(data[b_off + (off ^ 2)]) << 16) |
+                  (static_cast<uint32_t>(data[b_off + (off ^ 1)]) << 8) |
+                  (static_cast<uint32_t>(data[b_off + (off ^ 0)]) << 0);
+    }
+  }
+
+  uint32_t word = 0x80u << (rb_rem_bytes << 3);
+  const size_t off = rb_full_words << 2;
+
+  for (size_t i = 0; i < rb_rem_bytes; i++) {
+    word |= static_cast<uint32_t>(data[b_off + off + i]) << (i << 3);
+  }
+
+  const uint32_t words[2] = { 0u, word };
+  buffer[rb_full_words] = words[rb_full_words < RATE_W];
+
+  rho1(state, buffer);
+
+  constexpr uint32_t consts[2] = { CONST_A1, CONST_A0 };
+  state[(RATE_W << 1) - 1] ^= consts[rb_full_words < RATE_W];
+
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
+    state[i] ^= state[RATE_W ^ i];
+  }
+
+  sparkle::sparkle<4ul, 10ul>(state);
+}
+
+// Consumes non-empty plain text data into 256 -bit permutation state, while
+// producing equal many cipher text bytes, using algorithm 2.17 of Sparkle
+// specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+static inline void
+process_plain_text(
+  uint32_t* const __restrict state,    // 256 -bit permutation state
+  const uint8_t* const __restrict txt, // N (>0) -bytes plain text
+  uint8_t* const __restrict enc,       // N (>0) -bytes encrypted text
+  const size_t ct_len                  // len(txt) = len(enc) = N | N > 0
+)
+{
+  uint32_t buffer0[RATE_W + 1];
+  uint32_t buffer1[RATE_W];
+
+  size_t r_bytes = ct_len;
+  while (r_bytes > RATE) {
+    const size_t b_off = ct_len - r_bytes;
+
+    if constexpr (is_little_endian()) {
+      std::memcpy(buffer0, txt + b_off, RATE);
+    } else {
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+      for (size_t i = 0; i < RATE_W; i++) {
+        const size_t i_off = i << 2;
+
+        buffer0[i] = (static_cast<uint32_t>(txt[b_off + (i_off ^ 3)]) << 24) |
+                     (static_cast<uint32_t>(txt[b_off + (i_off ^ 2)]) << 16) |
+                     (static_cast<uint32_t>(txt[b_off + (i_off ^ 1)]) << 8) |
+                     (static_cast<uint32_t>(txt[b_off + (i_off ^ 0)]) << 0);
+      }
+    }
+
+    std::memcpy(buffer1, state, RATE);
+    rho2(buffer1, buffer0);
+
+    if constexpr (is_little_endian()) {
+      std::memcpy(enc + b_off, buffer1, RATE);
+    } else {
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+      for (size_t i = 0; i < RATE_W; i++) {
+        const size_t i_off = i << 2;
+
+        enc[b_off + (i_off ^ 0)] = static_cast<uint8_t>(buffer1[i] >> 0);
+        enc[b_off + (i_off ^ 1)] = static_cast<uint8_t>(buffer1[i] >> 8);
+        enc[b_off + (i_off ^ 2)] = static_cast<uint8_t>(buffer1[i] >> 16);
+        enc[b_off + (i_off ^ 3)] = static_cast<uint8_t>(buffer1[i] >> 24);
+      }
+    }
+
+    rho1(state, buffer0);
+
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+    for (size_t i = 0; i < RATE_W; i++) {
+      state[i] ^= state[RATE_W ^ i];
+    }
+
+    sparkle::sparkle<4ul, 7ul>(state);
+
+    r_bytes -= RATE;
+  }
+
+  const size_t b_off = ct_len - r_bytes;
+  const size_t rb_full_words = r_bytes >> 2;
+  const size_t rb_rem_bytes = r_bytes & 3ul;
+  const size_t w_off = rb_full_words << 2;
+
+  std::memset(buffer0, 0, RATE);
+
+  if constexpr (is_little_endian()) {
+    std::memcpy(buffer0, txt + b_off, rb_full_words << 2);
+  } else {
+    for (size_t i = 0; i < rb_full_words; i++) {
+      const size_t i_off = i << 2;
+
+      buffer0[i] = (static_cast<uint32_t>(txt[b_off + (i_off ^ 3)]) << 24) |
+                   (static_cast<uint32_t>(txt[b_off + (i_off ^ 2)]) << 16) |
+                   (static_cast<uint32_t>(txt[b_off + (i_off ^ 1)]) << 8) |
+                   (static_cast<uint32_t>(txt[b_off + (i_off ^ 0)]) << 0);
+    }
+  }
+
+  uint32_t word = 0x80u << (rb_rem_bytes << 3);
+  for (size_t i = 0; i < rb_rem_bytes; i++) {
+    const size_t idx = b_off + w_off + i;
+
+    word |= static_cast<uint32_t>(txt[idx]) << (i << 3);
+  }
+
+  const uint32_t words[2] = { 0u, word };
+  buffer0[rb_full_words] = words[rb_full_words < RATE_W];
+
+  std::memcpy(buffer1, state, RATE);
+  rho2(buffer1, buffer0);
+
+  if constexpr (is_little_endian()) {
+    std::memcpy(enc + b_off, buffer1, rb_full_words << 2);
+  } else {
+    for (size_t i = 0; i < rb_full_words; i++) {
+      const size_t i_off = i << 2;
+
+      enc[b_off + (i_off ^ 0)] = static_cast<uint8_t>(buffer1[i] >> 0);
+      enc[b_off + (i_off ^ 1)] = static_cast<uint8_t>(buffer1[i] >> 8);
+      enc[b_off + (i_off ^ 2)] = static_cast<uint8_t>(buffer1[i] >> 16);
+      enc[b_off + (i_off ^ 3)] = static_cast<uint8_t>(buffer1[i] >> 24);
+    }
+  }
+
+  for (size_t i = 0; i < rb_rem_bytes; i++) {
+    const size_t idx = b_off + w_off + i;
+
+    enc[idx] = static_cast<uint8_t>(buffer1[rb_full_words] >> (i << 3));
+  }
+
+  rho1(state, buffer0);
+
+  constexpr uint32_t consts[2] = { CONST_M1, CONST_M0 };
+  state[(RATE_W << 1) - 1] ^= consts[rb_full_words < RATE_W];
+
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
+    state[i] ^= state[RATE_W ^ i];
+  }
+
+  sparkle::sparkle<4ul, 10ul>(state);
+}
+
+// Consumes non-empty ( N -many | N > 0 ) encrypted text into 256 -bit
+// permutation state, while producing equal many decrypted text bytes, using
+// algorithm 2.18 of Sparkle specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+static inline void
+process_cipher_text(
+  uint32_t* const __restrict state,    // 256 -bit permutation state
+  const uint8_t* const __restrict enc, // N (>0) -bytes encrypted text
+  uint8_t* const __restrict dec,       // N (>0) -bytes decrypted text
+  const size_t ct_len                  // len(enc) = len(dec) = N | N > 0
+)
+{
+  uint32_t buffer0[RATE_W + 1ul];
+  uint32_t buffer1[RATE_W];
+
+  size_t r_bytes = ct_len;
+  while (r_bytes > RATE) {
+    const size_t b_off = ct_len - r_bytes;
+
+    if constexpr (is_little_endian()) {
+      std::memcpy(buffer0, enc + b_off, RATE);
+    } else {
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+      for (size_t i = 0; i < RATE_W; i++) {
+        const size_t i_off = i << 2;
+
+        buffer0[i] = (static_cast<uint32_t>(enc[b_off + (i_off ^ 3)]) << 24) |
+                     (static_cast<uint32_t>(enc[b_off + (i_off ^ 2)]) << 16) |
+                     (static_cast<uint32_t>(enc[b_off + (i_off ^ 1)]) << 8) |
+                     (static_cast<uint32_t>(enc[b_off + (i_off ^ 0)]) << 0);
+      }
+    }
+
+    std::memcpy(buffer1, state, RATE);
+    rhoprime2(buffer1, buffer0);
+
+    if constexpr (is_little_endian()) {
+      std::memcpy(dec + b_off, buffer1, RATE);
+    } else {
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+      for (size_t i = 0; i < RATE_W; i++) {
+        const size_t i_off = i << 2;
+
+        dec[b_off + (i_off ^ 0)] = static_cast<uint8_t>(buffer1[i] >> 0);
+        dec[b_off + (i_off ^ 1)] = static_cast<uint8_t>(buffer1[i] >> 8);
+        dec[b_off + (i_off ^ 2)] = static_cast<uint8_t>(buffer1[i] >> 16);
+        dec[b_off + (i_off ^ 3)] = static_cast<uint8_t>(buffer1[i] >> 24);
+      }
+    }
+
+    rhoprime1(state, buffer0);
+
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+    for (size_t i = 0; i < RATE_W; i++) {
+      state[i] ^= state[RATE_W ^ i];
+    }
+
+    sparkle::sparkle<4ul, 7ul>(state);
+
+    r_bytes -= RATE;
+  }
+
+  const size_t b_off = ct_len - r_bytes;
+  const size_t rb_full_words = r_bytes >> 2;
+  const size_t rb_rem_bytes = r_bytes & 3ul;
+  const size_t w_off = rb_full_words << 2;
+
+  std::memset(buffer0, 0, RATE);
+
+  if constexpr (is_little_endian()) {
+    std::memcpy(buffer0, enc + b_off, rb_full_words << 2);
+  } else {
+    for (size_t i = 0; i < rb_full_words; i++) {
+      const size_t i_off = i << 2;
+
+      buffer0[i] = (static_cast<uint32_t>(enc[b_off + (i_off ^ 3)]) << 24) |
+                   (static_cast<uint32_t>(enc[b_off + (i_off ^ 2)]) << 16) |
+                   (static_cast<uint32_t>(enc[b_off + (i_off ^ 1)]) << 8) |
+                   (static_cast<uint32_t>(enc[b_off + (i_off ^ 0)]) << 0);
+    }
+  }
+
+  uint32_t word = 0x80u << (rb_rem_bytes << 3);
+  for (size_t i = 0; i < rb_rem_bytes; i++) {
+    const size_t idx = b_off + w_off + i;
+
+    word |= static_cast<uint32_t>(enc[idx]) << (i << 3);
+  }
+
+  const uint32_t words[2] = { 0u, word };
+  buffer0[rb_full_words] = words[rb_full_words < RATE_W];
+
+  std::memcpy(buffer1, state, RATE);
+  rhoprime2(buffer1, buffer0);
+
+  if constexpr (is_little_endian()) {
+    std::memcpy(dec + b_off, buffer1, rb_full_words << 2);
+  } else {
+    for (size_t i = 0; i < rb_full_words; i++) {
+      const size_t i_off = i << 2;
+
+      dec[b_off + (i_off ^ 0)] = static_cast<uint8_t>(buffer1[i] >> 0);
+      dec[b_off + (i_off ^ 1)] = static_cast<uint8_t>(buffer1[i] >> 8);
+      dec[b_off + (i_off ^ 2)] = static_cast<uint8_t>(buffer1[i] >> 16);
+      dec[b_off + (i_off ^ 3)] = static_cast<uint8_t>(buffer1[i] >> 24);
+    }
+  }
+
+  for (size_t i = 0; i < rb_rem_bytes; i++) {
+    const size_t idx = b_off + w_off + i;
+
+    dec[idx] = static_cast<uint8_t>(buffer1[rb_full_words] >> (i << 3));
+  }
+
+  if (r_bytes < RATE) {
+    std::memset(buffer1 + rb_full_words, 0, RATE - w_off);
+
+    uint32_t word = 0x80u << (rb_rem_bytes << 3);
+
+    for (size_t i = 0; i < rb_rem_bytes; i++) {
+      const size_t idx = b_off + w_off + i;
+
+      word |= static_cast<uint32_t>(dec[idx]) << (i << 3);
+    }
+
+    buffer1[rb_full_words] = word;
+
+    rho1(state, buffer1);
+  } else {
+    rhoprime1(state, buffer0);
+  }
+
+  constexpr uint32_t consts[2] = { CONST_M1, CONST_M0 };
+  state[(RATE_W << 1) - 1ul] ^= consts[rb_full_words < RATE_W];
+
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
+    state[i] ^= state[RATE_W ^ i];
+  }
+
+  sparkle::sparkle<4ul, 10ul>(state);
+}
+
+// Finalization step of Schwaemm128-128 AEAD, where 16 -bytes of authentication
+// tag is produced
+//
+// See algorithm 2.18 of Sparkle specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+static inline void
+finalize(
+  const uint32_t* const __restrict state, // 256 -bit of permutation state
+  const uint8_t* const __restrict key,    // 16 -bytes secret key
+  uint8_t* const __restrict tag           // 16 -bytes authentication tag
+)
+{
+  uint32_t buffer[RATE_W];
+
+  if constexpr (is_little_endian()) {
+    std::memcpy(buffer, key, RATE);
+  } else {
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+    for (size_t i = 0; i < RATE_W; i++) {
+      const size_t b_off = i << 2;
+
+      buffer[i] = (static_cast<uint32_t>(key[b_off ^ 3]) << 24) |
+                  (static_cast<uint32_t>(key[b_off ^ 2]) << 16) |
+                  (static_cast<uint32_t>(key[b_off ^ 1]) << 8) |
+                  (static_cast<uint32_t>(key[b_off ^ 0]) << 0);
+    }
+  }
+
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
+    buffer[i] ^= state[RATE_W ^ i];
+  }
+
+  if constexpr (is_little_endian()) {
+    std::memcpy(tag, buffer, RATE);
+  } else {
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+    for (size_t i = 0; i < RATE_W; i++) {
+      const size_t b_off = i << 2;
+      const uint32_t t_word = buffer[i];
+
+      tag[b_off ^ 0] = static_cast<uint8_t>(t_word >> 0);
+      tag[b_off ^ 1] = static_cast<uint8_t>(t_word >> 8);
+      tag[b_off ^ 2] = static_cast<uint8_t>(t_word >> 16);
+      tag[b_off ^ 3] = static_cast<uint8_t>(t_word >> 24);
+    }
+  }
+}
+
+// Schwaemm128-128 authenticated encryption, which computes N (>=0) -bytes of
+// cipher text from equal many bytes of plain text, given 16 -bytes secret key,
+// 16 -bytes public message nonce & M (>=0 ) -bytes associated data ( never
+// encrypted )
+//
+// Schwaemm128-128 AEAD scheme provides confidentiality ( only for plain text ),
+// authenticity & integrity ( for both plain text & associated data ), which
+// results into generation of 16 -bytes authentication tag ( during encryption
+// ), which must be checked for equality ( during decryption ) before consuming
+// decrypted bytes !
+//
+// See algorithm 2.17 of Sparkle Specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+static inline void
+encrypt(const uint8_t* const __restrict key,   // 16 -bytes secret key
+        const uint8_t* const __restrict nonce, // 16 -bytes nonce
+        const uint8_t* const __restrict data,  // N (>=0) -bytes associated data
+        const size_t d_len,                    // len(data) = N | N >= 0
+        const uint8_t* const __restrict txt,   // N (>=0) -bytes plain text
+        uint8_t* const __restrict enc,         // N (>=0) -bytes cipher text
+        const size_t ct_len,                   // len(txt) = len(enc) = N | >= 0
+        uint8_t* const __restrict tag          // 16 -bytes authentication tag
+)
+{
+  uint32_t state[8];
+
+  initialize(state, key, nonce);
+
+  if (d_len > 0) {
+    process_associated_data(state, data, d_len);
+  }
+  if (ct_len > 0) {
+    process_plain_text(state, txt, enc, ct_len);
+  }
+
+  finalize(state, key, tag);
+}
+
+// Schwaemm128-128 verified decryption, which computes N (>=0) -bytes of
+// deciphered text from equal many bytes of encrypted text, given 16 -bytes
+// secret key, 16 -bytes public message nonce, 16 -bytes authentication tag &
+// M (>=0) -bytes associated data ( never encrypted )
+//
+// Schwaemm128-128 AEAD scheme provides confidentiality ( only for plain text ),
+// authenticity & integrity ( for both plain text & associated data ), which
+// results into generation of 16 -bytes authentication tag ( during encryption
+// ), which is checked for equality during decryption & equality test result is
+// returned from this function
+//
+// Note, before consuming decrypted bytes ( pointed to by `dec` ), one must
+// check for truth value of this function's return value.
+//
+// See algorithm 2.18 of Sparkle Specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+static inline bool
+decrypt(const uint8_t* const __restrict key,   // 16 -bytes secret key
+        const uint8_t* const __restrict nonce, // 16 -bytes nonce
+        const uint8_t* const __restrict tag,   // 16 -bytes authentication tag
+        const uint8_t* const __restrict data,  // N (>=0) -bytes associated data
+        const size_t d_len,                    // len(data) = N | N >= 0
+        const uint8_t* const __restrict enc,   // N (>=0) -bytes encrypted text
+        uint8_t* const __restrict dec,         // N (>=0) -bytes decrypted text
+        const size_t ct_len                    // len(enc) = len(dec) = N | >= 0
+)
+{
+  uint32_t state[8];
+  uint8_t tag_[RATE];
+
+  initialize(state, key, nonce);
+
+  if (d_len > 0) {
+    process_associated_data(state, data, d_len);
+  }
+  if (ct_len > 0) {
+    process_cipher_text(state, enc, dec, ct_len);
+  }
+
+  finalize(state, key, tag_);
+
+  bool flag = false;
+  for (size_t i = 0; i < RATE; i++) {
+    flag |= (tag[i] ^ tag_[i]);
+  }
+  return !flag;
+}
+
+}

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,9 +1,16 @@
 #pragma once
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <iomanip>
 #include <random>
 #include <sstream>
+
+consteval static inline bool
+is_little_endian()
+{
+  return std::endian::native == std::endian::little;
+}
 
 // Given a bytearray of length N, this function converts it to human readable
 // hex string of length N << 1

--- a/test_kat.sh
+++ b/test_kat.sh
@@ -20,6 +20,7 @@ cp sparkle/Implementations/crypto_hash/esch256v2/LWC_HASH_KAT_256.txt ../
 cp sparkle/Implementations/crypto_hash/esch384v2/LWC_HASH_KAT_384.txt ../
 cp sparkle/Implementations/crypto_aead/schwaemm256128v2/LWC_AEAD_KAT_128_256.txt ../
 cp sparkle/Implementations/crypto_aead/schwaemm192192v2/LWC_AEAD_KAT_192_192.txt ../
+cp sparkle/Implementations/crypto_aead/schwaemm128128v2/LWC_AEAD_KAT_128_128.txt ../
 
 popd
 
@@ -33,6 +34,7 @@ mv LWC_HASH_KAT_256.txt wrapper/python/
 mv LWC_HASH_KAT_384.txt wrapper/python/
 mv LWC_AEAD_KAT_128_256.txt wrapper/python/
 mv LWC_AEAD_KAT_192_192.txt wrapper/python/
+mv LWC_AEAD_KAT_128_128.txt wrapper/python/
 
 # ---
 

--- a/wrapper/python/sparkle.py
+++ b/wrapper/python/sparkle.py
@@ -205,5 +205,76 @@ def schwaemm192_192_decrypt(
     return f, dec_
 
 
+def schwaemm128_128_encrypt(
+    key: bytes, nonce: bytes, data: bytes, text: bytes
+) -> Tuple[bytes, bytes]:
+    """
+    Encrypts M ( >=0 ) -many plain text bytes, while using 16 -bytes secret key,
+    16 -bytes public message nonce & N ( >=0 ) -bytes associated data, while producing
+    M -bytes cipher text & 16 -bytes authentication tag ( in order )
+    """
+    assert len(key) == 16, "Schwaemm128-128 takes 16 -bytes secret key !"
+    assert len(nonce) == 16, "Schwaemm128-128 takes 16 -bytes nonce !"
+
+    ad_len = len(data)
+    ct_len = len(text)
+
+    key_ = np.frombuffer(key, dtype=u8)
+    nonce_ = np.frombuffer(nonce, dtype=u8)
+    data_ = np.frombuffer(data, dtype=u8)
+    text_ = np.frombuffer(text, dtype=u8)
+    enc = np.empty(ct_len, dtype=u8)
+    tag = np.empty(16, dtype=u8)
+
+    args = [uint8_tp, uint8_tp, uint8_tp, len_t,
+            uint8_tp, uint8_tp, len_t, uint8_tp]
+    SO_LIB.schwaemm128_128_encrypt.argtypes = args
+
+    SO_LIB.schwaemm128_128_encrypt(key_, nonce_, data_, ad_len,
+                                   text_, enc, ct_len, tag)
+
+    enc_ = enc.tobytes()
+    tag_ = tag.tobytes()
+
+    return enc_, tag_
+
+
+def schwaemm128_128_decrypt(
+    key: bytes, nonce: bytes, tag: bytes, data: bytes, enc: bytes
+) -> Tuple[bool, bytes]:
+    """
+    Decrypts M ( >=0 ) -many cipher text bytes, while using 16 -bytes secret key,
+    16 -bytes public message nonce, 16 -bytes authentication tag & N ( >=0 ) -bytes
+    associated data, while producing boolean flag denoting verification status ( which 
+    must hold truth value, check before consuming decrypted output bytes ) &
+    M -bytes plain text ( in order )
+    """
+    assert len(key) == 16, "Schwaemm128-128 takes 16 -bytes secret key !"
+    assert len(nonce) == 16, "Schwaemm128-128 takes 16 -bytes nonce !"
+    assert len(tag) == 16, "Schwaemm128-128 takes 16 -bytes authentication tag !"
+
+    ad_len = len(data)
+    ct_len = len(enc)
+
+    key_ = np.frombuffer(key, dtype=u8)
+    nonce_ = np.frombuffer(nonce, dtype=u8)
+    tag_ = np.frombuffer(tag, dtype=u8)
+    data_ = np.frombuffer(data, dtype=u8)
+    enc_ = np.frombuffer(enc, dtype=u8)
+    dec = np.empty(ct_len, dtype=u8)
+
+    args = [uint8_tp, uint8_tp, uint8_tp,
+            uint8_tp, len_t, uint8_tp, uint8_tp, len_t]
+    SO_LIB.schwaemm128_128_decrypt.argtypes = args
+    SO_LIB.schwaemm128_128_decrypt.restype = bool_t
+
+    f = SO_LIB.schwaemm128_128_decrypt(key_, nonce_, tag_, data_,
+                                       ad_len, enc_, dec, ct_len)
+
+    dec_ = dec.tobytes()
+
+    return f, dec_
+
+
 if __name__ == '__main__':
     print('Use `sparkle` as library module !')

--- a/wrapper/python/test_sparkle.py
+++ b/wrapper/python/test_sparkle.py
@@ -228,5 +228,76 @@ def test_schwaemm192_192_kat():
             fd.readline()
 
 
+def test_schwaemm128_128_kat():
+    """
+    Tests functional correctness of Schwaemm128-128 AEAD implementation, using
+    Known Answer Tests submitted along with final round submission of Sparkle in NIST LWC
+
+    See https://csrc.nist.gov/projects/lightweight-cryptography/finalists
+    """
+
+    from sparkle import schwaemm128_128_encrypt, schwaemm128_128_decrypt
+
+    with open("LWC_AEAD_KAT_128_128.txt", "r") as fd:
+        while True:
+            cnt = fd.readline()
+            if not cnt:
+                # no more KATs remaining
+                break
+
+            key = fd.readline()
+            nonce = fd.readline()
+            pt = fd.readline()
+            ad = fd.readline()
+            ct = fd.readline()
+
+            # extract out required fields
+            cnt = int([i.strip() for i in cnt.split("=")][-1])
+            key = [i.strip() for i in key.split("=")][-1]
+            nonce = [i.strip() for i in nonce.split("=")][-1]
+            pt = [i.strip() for i in pt.split("=")][-1]
+            ad = [i.strip() for i in ad.split("=")][-1]
+            ct = [i.strip() for i in ct.split("=")][-1]
+
+            # 128 -bit secret key
+            key = int(f"0x{key}", base=16).to_bytes(16, "big")
+            # 128 -bit public message nonce
+            nonce = int(f"0x{nonce}", base=16).to_bytes(16, "big")
+            # plain text
+            pt = bytes(
+                [
+                    int(f"0x{pt[(i << 1): ((i+1) << 1)]}", base=16)
+                    for i in range(len(pt) >> 1)
+                ]
+            )
+            # associated data
+            ad = bytes(
+                [
+                    int(f"0x{ad[(i << 1): ((i+1) << 1)]}", base=16)
+                    for i in range(len(ad) >> 1)
+                ]
+            )
+            # cipher text + authentication tag ( expected )
+            ct = bytes(
+                [
+                    int(f"0x{ct[(i << 1): ((i+1) << 1)]}", base=16)
+                    for i in range(len(ct) >> 1)
+                ]
+            )
+
+            cipher, tag = schwaemm128_128_encrypt(key, nonce, ad, pt)
+            flag, text = schwaemm128_128_decrypt(key, nonce, tag, ad, cipher)
+
+            assert (
+                cipher + tag == ct
+            ), f"[Schwaemm128-128 KAT {cnt}] expected cipher to be 0x{ct.hex()}, found 0x${(cipher + tag).hex()} !"
+            assert (
+                pt == text and flag
+            ), f"[Schwaemm128-128 KAT {cnt}] expected plain text 0x{pt.hex()}, found 0x{text.hex()} !"
+
+            # don't need this line, so discard
+            fd.readline()
+
+
 if __name__ == '__main__':
     print('Use `pytest` for driving Sparkle tests against Known Answer Tests ( KAT ) !')

--- a/wrapper/schwaemm.hpp
+++ b/wrapper/schwaemm.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "schwaemm128_128.hpp"
 #include "schwaemm192_192.hpp"
 #include "schwaemm256_128.hpp"
 
@@ -38,6 +39,24 @@ extern "C"
                                uint8_t* const __restrict);
 
   bool schwaemm192_192_decrypt(const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const size_t,
+                               const uint8_t* const __restrict,
+                               uint8_t* const __restrict,
+                               const size_t);
+
+  void schwaemm128_128_encrypt(const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const size_t,
+                               const uint8_t* const __restrict,
+                               uint8_t* const __restrict,
+                               const size_t,
+                               uint8_t* const __restrict);
+
+  bool schwaemm128_128_decrypt(const uint8_t* const __restrict,
                                const uint8_t* const __restrict,
                                const uint8_t* const __restrict,
                                const uint8_t* const __restrict,
@@ -115,6 +134,40 @@ extern "C"
                                const size_t ct_len)
   {
     using namespace schwaemm192_192;
+    return decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
+  }
+
+  // Given 16 -bytes secret key, 16 -bytes nonce, N -bytes plain text & M -bytes
+  // associated data, this routine computes N -bytes cipher text & 16 -bytes
+  // authentication tag | N, M >= 0
+  void schwaemm128_128_encrypt(const uint8_t* const __restrict key,
+                               const uint8_t* const __restrict nonce,
+                               const uint8_t* const __restrict data,
+                               const size_t d_len,
+                               const uint8_t* const __restrict txt,
+                               uint8_t* const __restrict enc,
+                               const size_t ct_len,
+                               uint8_t* const __restrict tag)
+  {
+    schwaemm128_128::encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+  }
+
+  // Given 16 -bytes secret key, 16 -bytes nonce, 16 -bytes authentication tag,
+  // N -bytes cipher text & M -bytes associated data, this routine computes N
+  // -bytes deciphered text & a boolean verification flag | N, M >= 0
+  //
+  // Before consuming decrypted bytes ensure presence of truth value in returned
+  // boolean flag !
+  bool schwaemm128_128_decrypt(const uint8_t* const __restrict key,
+                               const uint8_t* const __restrict nonce,
+                               const uint8_t* const __restrict tag,
+                               const uint8_t* const __restrict data,
+                               const size_t d_len,
+                               const uint8_t* const __restrict enc,
+                               uint8_t* const __restrict dec,
+                               const size_t ct_len)
+  {
+    using namespace schwaemm128_128;
     return decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
   }
 }


### PR DESCRIPTION
Check for endianess of CPU system ( in compile-time ), to decide whether `std::memcpy` can be used for copying multi-byte ( little endian ) primitive data types. 