### PR TITLE
Use `std::memcpy` on little endian CPU systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,93 +79,93 @@ make benchmark
 ### On ARM Cortex-A72
 
 ```bash
-2022-05-30T06:53:40+00:00
+2022-05-30T08:10:37+00:00
 Running ./bench/a.out
 Run on (16 X 166.66 MHz CPU s)
 CPU Caches:
   L1 Data 32 KiB (x16)
   L1 Instruction 48 KiB (x16)
   L2 Unified 2048 KiB (x4)
-Load Average: 0.24, 0.06, 0.02
+Load Average: 0.26, 0.06, 0.02
 ------------------------------------------------------------------------------------------
 Benchmark                                Time             CPU   Iterations UserCounters...
 ------------------------------------------------------------------------------------------
-esch256_hash/64                        879 ns          879 ns       795503 bytes_per_second=69.4103M/s
-esch256_hash/128                      1488 ns         1488 ns       470565 bytes_per_second=82.0615M/s
-esch256_hash/256                      2688 ns         2688 ns       260377 bytes_per_second=90.8133M/s
-esch256_hash/512                      5090 ns         5090 ns       137514 bytes_per_second=95.9297M/s
-esch256_hash/1024                     9894 ns         9894 ns        70748 bytes_per_second=98.707M/s
-esch256_hash/2048                    19500 ns        19500 ns        35896 bytes_per_second=100.162M/s
-esch256_hash/4096                    38714 ns        38714 ns        18081 bytes_per_second=100.901M/s
-esch384_hash/64                       2582 ns         2582 ns       271343 bytes_per_second=23.6355M/s
-esch384_hash/128                      4132 ns         4132 ns       169413 bytes_per_second=29.5435M/s
-esch384_hash/256                      7240 ns         7240 ns        96685 bytes_per_second=33.7211M/s
-esch384_hash/512                     13457 ns        13457 ns        52016 bytes_per_second=36.285M/s
-esch384_hash/1024                    25895 ns        25894 ns        27031 bytes_per_second=37.7133M/s
-esch384_hash/2048                    50761 ns        50761 ns        13790 bytes_per_second=38.4771M/s
-esch384_hash/4096                   100497 ns       100495 ns         6965 bytes_per_second=38.8701M/s
-schwaemm256_128_encrypt/64/32         1189 ns         1189 ns       588654 bytes_per_second=76.9925M/s
-schwaemm256_128_decrypt/64/32         1192 ns         1192 ns       587163 bytes_per_second=76.7918M/s
-schwaemm256_128_encrypt/128/32        1634 ns         1634 ns       428609 bytes_per_second=93.4006M/s
-schwaemm256_128_decrypt/128/32        1641 ns         1641 ns       426424 bytes_per_second=92.9614M/s
-schwaemm256_128_encrypt/256/32        2522 ns         2522 ns       277575 bytes_per_second=108.915M/s
-schwaemm256_128_decrypt/256/32        2551 ns         2551 ns       273686 bytes_per_second=107.666M/s
-schwaemm256_128_encrypt/512/32        4290 ns         4290 ns       163165 bytes_per_second=120.931M/s
-schwaemm256_128_decrypt/512/32        4350 ns         4350 ns       160927 bytes_per_second=119.271M/s
-schwaemm256_128_encrypt/1024/32       7829 ns         7829 ns        89432 bytes_per_second=128.641M/s
-schwaemm256_128_decrypt/1024/32       7953 ns         7953 ns        88014 bytes_per_second=126.633M/s
-schwaemm256_128_encrypt/2048/32      14900 ns        14899 ns        46982 bytes_per_second=133.135M/s
-schwaemm256_128_decrypt/2048/32      15161 ns        15161 ns        46172 bytes_per_second=130.843M/s
-schwaemm256_128_encrypt/4096/32      29045 ns        29045 ns        24100 bytes_per_second=135.54M/s
-schwaemm256_128_decrypt/4096/32      29569 ns        29569 ns        23674 bytes_per_second=133.139M/s
-schwaemm192_192_encrypt/64/32         1495 ns         1495 ns       468089 bytes_per_second=61.2235M/s
-schwaemm192_192_decrypt/64/32         1571 ns         1571 ns       445558 bytes_per_second=58.2635M/s
-schwaemm192_192_encrypt/128/32        2071 ns         2071 ns       337916 bytes_per_second=73.6894M/s
-schwaemm192_192_decrypt/128/32        2162 ns         2162 ns       323751 bytes_per_second=70.5726M/s
-schwaemm192_192_encrypt/256/32        3015 ns         3015 ns       232192 bytes_per_second=91.1051M/s
-schwaemm192_192_decrypt/256/32        3156 ns         3156 ns       221793 bytes_per_second=87.0406M/s
-schwaemm192_192_encrypt/512/32        5090 ns         5090 ns       137502 bytes_per_second=101.917M/s
-schwaemm192_192_decrypt/512/32        5322 ns         5322 ns       131506 bytes_per_second=97.4742M/s
-schwaemm192_192_encrypt/1024/32       9057 ns         9057 ns        77282 bytes_per_second=111.192M/s
-schwaemm192_192_decrypt/1024/32       9462 ns         9462 ns        73981 bytes_per_second=106.434M/s
-schwaemm192_192_encrypt/2048/32      17176 ns        17176 ns        40756 bytes_per_second=115.491M/s
-schwaemm192_192_decrypt/2048/32      17935 ns        17935 ns        39029 bytes_per_second=110.605M/s
-schwaemm192_192_encrypt/4096/32      33229 ns        33228 ns        21067 bytes_per_second=118.477M/s
-schwaemm192_192_decrypt/4096/32      34687 ns        34687 ns        20181 bytes_per_second=113.495M/s
-schwaemm128_128_encrypt/64/32         1129 ns         1129 ns       619947 bytes_per_second=81.0857M/s
-schwaemm128_128_decrypt/64/32         1134 ns         1134 ns       617088 bytes_per_second=80.7116M/s
-schwaemm128_128_encrypt/128/32        1679 ns         1679 ns       416793 bytes_per_second=90.8546M/s
-schwaemm128_128_decrypt/128/32        1668 ns         1668 ns       419705 bytes_per_second=91.4914M/s
-schwaemm128_128_encrypt/256/32        2766 ns         2765 ns       253105 bytes_per_second=99.3169M/s
-schwaemm128_128_decrypt/256/32        2719 ns         2719 ns       257436 bytes_per_second=101.015M/s
-schwaemm128_128_encrypt/512/32        4938 ns         4938 ns       141772 bytes_per_second=105.072M/s
-schwaemm128_128_decrypt/512/32        4822 ns         4821 ns       145186 bytes_per_second=107.602M/s
-schwaemm128_128_encrypt/1024/32       9282 ns         9282 ns        75418 bytes_per_second=108.503M/s
-schwaemm128_128_decrypt/1024/32       9026 ns         9026 ns        77548 bytes_per_second=111.572M/s
-schwaemm128_128_encrypt/2048/32      17969 ns        17969 ns        38954 bytes_per_second=110.391M/s
-schwaemm128_128_decrypt/2048/32      17437 ns        17437 ns        40146 bytes_per_second=113.763M/s
-schwaemm128_128_encrypt/4096/32      35136 ns        35135 ns        19922 bytes_per_second=112.045M/s
-schwaemm128_128_decrypt/4096/32      34257 ns        34256 ns        20433 bytes_per_second=114.921M/s
-schwaemm256_256_encrypt/64/32         2288 ns         2288 ns       305929 bytes_per_second=40.0081M/s
-schwaemm256_256_decrypt/64/32         2372 ns         2372 ns       294924 bytes_per_second=38.5973M/s
-schwaemm256_256_encrypt/128/32        3114 ns         3114 ns       224872 bytes_per_second=48.9992M/s
-schwaemm256_256_decrypt/128/32        3222 ns         3222 ns       217095 bytes_per_second=47.356M/s
-schwaemm256_256_encrypt/256/32        4741 ns         4741 ns       147522 bytes_per_second=57.9291M/s
-schwaemm256_256_decrypt/256/32        4912 ns         4912 ns       142479 bytes_per_second=55.9205M/s
-schwaemm256_256_encrypt/512/32        8002 ns         8001 ns        87452 bytes_per_second=64.8382M/s
-schwaemm256_256_decrypt/512/32        8293 ns         8293 ns        84376 bytes_per_second=62.5598M/s
-schwaemm256_256_encrypt/1024/32      14518 ns        14517 ns        48207 bytes_per_second=69.371M/s
-schwaemm256_256_decrypt/1024/32      15057 ns        15057 ns        46478 bytes_per_second=66.8853M/s
-schwaemm256_256_encrypt/2048/32      27536 ns        27536 ns        25418 bytes_per_second=72.0392M/s
-schwaemm256_256_decrypt/2048/32      28568 ns        28567 ns        24505 bytes_per_second=69.4383M/s
-schwaemm256_256_encrypt/4096/32      53598 ns        53597 ns        13060 bytes_per_second=73.4511M/s
-schwaemm256_256_decrypt/4096/32      55611 ns        55610 ns        12587 bytes_per_second=70.7924M/s
+esch256_hash/64                        879 ns          879 ns       795737 bytes_per_second=69.4144M/s
+esch256_hash/128                      1488 ns         1488 ns       470564 bytes_per_second=82.0623M/s
+esch256_hash/256                      2688 ns         2688 ns       260385 bytes_per_second=90.8156M/s
+esch256_hash/512                      5090 ns         5090 ns       137520 bytes_per_second=95.9291M/s
+esch256_hash/1024                     9893 ns         9893 ns        70752 bytes_per_second=98.7122M/s
+esch256_hash/2048                    19500 ns        19500 ns        35897 bytes_per_second=100.163M/s
+esch256_hash/4096                    38713 ns        38713 ns        18082 bytes_per_second=100.904M/s
+esch384_hash/64                       2587 ns         2587 ns       271018 bytes_per_second=23.5962M/s
+esch384_hash/128                      4132 ns         4132 ns       169352 bytes_per_second=29.5404M/s
+esch384_hash/256                      7241 ns         7241 ns        96679 bytes_per_second=33.7153M/s
+esch384_hash/512                     13460 ns        13460 ns        52010 bytes_per_second=36.2773M/s
+esch384_hash/1024                    25898 ns        25897 ns        27030 bytes_per_second=37.7094M/s
+esch384_hash/2048                    50763 ns        50763 ns        13788 bytes_per_second=38.4754M/s
+esch384_hash/4096                   100503 ns       100499 ns         6965 bytes_per_second=38.8686M/s
+schwaemm256_128_encrypt/64/32         1120 ns         1120 ns       625034 bytes_per_second=81.7501M/s
+schwaemm256_128_decrypt/64/32         1147 ns         1147 ns       610513 bytes_per_second=79.8481M/s
+schwaemm256_128_encrypt/128/32        1519 ns         1519 ns       460700 bytes_per_second=100.43M/s
+schwaemm256_128_decrypt/128/32        1545 ns         1545 ns       453014 bytes_per_second=98.7519M/s
+schwaemm256_128_encrypt/256/32        2327 ns         2327 ns       299629 bytes_per_second=118.041M/s
+schwaemm256_128_decrypt/256/32        2350 ns         2350 ns       297862 bytes_per_second=116.872M/s
+schwaemm256_128_encrypt/512/32        3923 ns         3923 ns       178431 bytes_per_second=132.238M/s
+schwaemm256_128_decrypt/512/32        3944 ns         3944 ns       177469 bytes_per_second=131.529M/s
+schwaemm256_128_encrypt/1024/32       7118 ns         7118 ns        98328 bytes_per_second=141.477M/s
+schwaemm256_128_decrypt/1024/32       7133 ns         7133 ns        98132 bytes_per_second=141.19M/s
+schwaemm256_128_encrypt/2048/32      13510 ns        13509 ns        51816 bytes_per_second=146.835M/s
+schwaemm256_128_decrypt/2048/32      13511 ns        13510 ns        51812 bytes_per_second=146.826M/s
+schwaemm256_128_encrypt/4096/32      26292 ns        26291 ns        26625 bytes_per_second=149.737M/s
+schwaemm256_128_decrypt/4096/32      26276 ns        26275 ns        26641 bytes_per_second=149.827M/s
+schwaemm192_192_encrypt/64/32         1495 ns         1495 ns       468214 bytes_per_second=61.24M/s
+schwaemm192_192_decrypt/64/32         1554 ns         1554 ns       450350 bytes_per_second=58.9061M/s
+schwaemm192_192_encrypt/128/32        2071 ns         2071 ns       335520 bytes_per_second=73.6829M/s
+schwaemm192_192_decrypt/128/32        2121 ns         2121 ns       327122 bytes_per_second=71.9501M/s
+schwaemm192_192_encrypt/256/32        3014 ns         3014 ns       232225 bytes_per_second=91.1157M/s
+schwaemm192_192_decrypt/256/32        3074 ns         3074 ns       227747 bytes_per_second=89.3623M/s
+schwaemm192_192_encrypt/512/32        5090 ns         5090 ns       137502 bytes_per_second=101.922M/s
+schwaemm192_192_decrypt/512/32        5150 ns         5149 ns       135903 bytes_per_second=100.749M/s
+schwaemm192_192_encrypt/1024/32       9057 ns         9057 ns        77285 bytes_per_second=111.194M/s
+schwaemm192_192_decrypt/1024/32       9116 ns         9116 ns        76786 bytes_per_second=110.472M/s
+schwaemm192_192_encrypt/2048/32      17176 ns        17176 ns        40754 bytes_per_second=115.49M/s
+schwaemm192_192_decrypt/2048/32      17235 ns        17235 ns        40614 bytes_per_second=115.093M/s
+schwaemm192_192_encrypt/4096/32      33229 ns        33229 ns        21066 bytes_per_second=118.475M/s
+schwaemm192_192_decrypt/4096/32      33298 ns        33298 ns        21018 bytes_per_second=118.228M/s
+schwaemm128_128_encrypt/64/32         1127 ns         1127 ns       620875 bytes_per_second=81.2045M/s
+schwaemm128_128_decrypt/64/32         1134 ns         1134 ns       617326 bytes_per_second=80.7393M/s
+schwaemm128_128_encrypt/128/32        1678 ns         1678 ns       417056 bytes_per_second=90.9174M/s
+schwaemm128_128_decrypt/128/32        1667 ns         1667 ns       419818 bytes_per_second=91.5156M/s
+schwaemm128_128_encrypt/256/32        2765 ns         2764 ns       253231 bytes_per_second=99.3551M/s
+schwaemm128_128_decrypt/256/32        2719 ns         2719 ns       257486 bytes_per_second=101.026M/s
+schwaemm128_128_encrypt/512/32        4936 ns         4936 ns       141816 bytes_per_second=105.105M/s
+schwaemm128_128_decrypt/512/32        4821 ns         4821 ns       145197 bytes_per_second=107.61M/s
+schwaemm128_128_encrypt/1024/32       9281 ns         9281 ns        75422 bytes_per_second=108.513M/s
+schwaemm128_128_decrypt/1024/32       9026 ns         9026 ns        77542 bytes_per_second=111.575M/s
+schwaemm128_128_encrypt/2048/32      17969 ns        17969 ns        38955 bytes_per_second=110.393M/s
+schwaemm128_128_decrypt/2048/32      17436 ns        17436 ns        40146 bytes_per_second=113.766M/s
+schwaemm128_128_encrypt/4096/32      35347 ns        35346 ns        19804 bytes_per_second=111.377M/s
+schwaemm128_128_decrypt/4096/32      34268 ns        34268 ns        20427 bytes_per_second=114.882M/s
+schwaemm256_256_encrypt/64/32         2295 ns         2295 ns       305004 bytes_per_second=39.8946M/s
+schwaemm256_256_decrypt/64/32         2371 ns         2371 ns       295050 bytes_per_second=38.6162M/s
+schwaemm256_256_encrypt/128/32        3115 ns         3115 ns       225002 bytes_per_second=48.9783M/s
+schwaemm256_256_decrypt/128/32        3221 ns         3221 ns       217152 bytes_per_second=47.3688M/s
+schwaemm256_256_encrypt/256/32        4734 ns         4734 ns       147934 bytes_per_second=58.0167M/s
+schwaemm256_256_decrypt/256/32        4915 ns         4915 ns       142568 bytes_per_second=55.8786M/s
+schwaemm256_256_encrypt/512/32        7979 ns         7979 ns        87756 bytes_per_second=65.0199M/s
+schwaemm256_256_decrypt/512/32        8295 ns         8295 ns        84383 bytes_per_second=62.5439M/s
+schwaemm256_256_encrypt/1024/32      14455 ns        14455 ns        48433 bytes_per_second=69.6691M/s
+schwaemm256_256_decrypt/1024/32      15049 ns        15049 ns        46514 bytes_per_second=66.9196M/s
+schwaemm256_256_encrypt/2048/32      27429 ns        27429 ns        25526 bytes_per_second=72.3199M/s
+schwaemm256_256_decrypt/2048/32      28570 ns        28569 ns        24503 bytes_per_second=69.4329M/s
+schwaemm256_256_encrypt/4096/32      53352 ns        53352 ns        13120 bytes_per_second=73.7892M/s
+schwaemm256_256_decrypt/4096/32      55628 ns        55627 ns        12583 bytes_per_second=70.7712M/s
 ```
 
 ### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
 
 ```bash
-2022-05-30T10:50:00+04:00
+2022-05-30T11:47:55+04:00
 Running ./bench/a.out
 Run on (8 X 2400 MHz CPU s)
 CPU Caches:
@@ -173,78 +173,78 @@ CPU Caches:
   L1 Instruction 32 KiB
   L2 Unified 256 KiB (x4)
   L3 Unified 6144 KiB
-Load Average: 5.22, 4.73, 3.97
+Load Average: 1.86, 2.21, 2.21
 ------------------------------------------------------------------------------------------
 Benchmark                                Time             CPU   Iterations UserCounters...
 ------------------------------------------------------------------------------------------
-esch256_hash/64                       1019 ns         1009 ns       683267 bytes_per_second=60.5206M/s
-esch256_hash/128                      1887 ns         1843 ns       374006 bytes_per_second=66.2434M/s
-esch256_hash/256                      3198 ns         3168 ns       212928 bytes_per_second=77.0606M/s
-esch256_hash/512                      6063 ns         6007 ns       117615 bytes_per_second=81.289M/s
-esch256_hash/1024                    11574 ns        11525 ns        59160 bytes_per_second=84.732M/s
-esch256_hash/2048                    23485 ns        23226 ns        30223 bytes_per_second=84.091M/s
-esch256_hash/4096                    45179 ns        45043 ns        15307 bytes_per_second=86.7233M/s
-esch384_hash/64                       1349 ns         1340 ns       529942 bytes_per_second=45.5352M/s
-esch384_hash/128                      2225 ns         2202 ns       317255 bytes_per_second=55.4412M/s
-esch384_hash/256                      4440 ns         4285 ns       178355 bytes_per_second=56.9771M/s
-esch384_hash/512                      8052 ns         7495 ns        96360 bytes_per_second=65.1486M/s
-esch384_hash/1024                    13690 ns        13624 ns        47993 bytes_per_second=71.679M/s
-esch384_hash/2048                    27788 ns        27475 ns        25713 bytes_per_second=71.0878M/s
-esch384_hash/4096                    55963 ns        55129 ns        13309 bytes_per_second=70.8571M/s
-schwaemm256_128_encrypt/64/32         1075 ns         1063 ns       644995 bytes_per_second=86.1231M/s
-schwaemm256_128_decrypt/64/32         1087 ns         1074 ns       654132 bytes_per_second=85.2757M/s
-schwaemm256_128_encrypt/128/32        1463 ns         1448 ns       473966 bytes_per_second=105.366M/s
-schwaemm256_128_decrypt/128/32        1471 ns         1458 ns       482942 bytes_per_second=104.656M/s
-schwaemm256_128_encrypt/256/32        2253 ns         2235 ns       315173 bytes_per_second=122.88M/s
-schwaemm256_128_decrypt/256/32        2218 ns         2202 ns       317676 bytes_per_second=124.73M/s
-schwaemm256_128_encrypt/512/32        3891 ns         3826 ns       140786 bytes_per_second=135.599M/s
-schwaemm256_128_decrypt/512/32        3758 ns         3730 ns       186354 bytes_per_second=139.077M/s
-schwaemm256_128_encrypt/1024/32       6789 ns         6744 ns       101800 bytes_per_second=149.322M/s
-schwaemm256_128_decrypt/1024/32       6851 ns         6797 ns       101457 bytes_per_second=148.164M/s
-schwaemm256_128_encrypt/2048/32      12917 ns        12836 ns        54010 bytes_per_second=154.539M/s
-schwaemm256_128_decrypt/2048/32      12925 ns        12850 ns        53394 bytes_per_second=154.371M/s
-schwaemm256_128_encrypt/4096/32      25077 ns        24931 ns        27663 bytes_per_second=157.906M/s
-schwaemm256_128_decrypt/4096/32      25190 ns        25026 ns        27956 bytes_per_second=157.308M/s
-schwaemm192_192_encrypt/64/32         1425 ns         1415 ns       490832 bytes_per_second=64.6873M/s
-schwaemm192_192_decrypt/64/32         1429 ns         1420 ns       487469 bytes_per_second=64.4903M/s
-schwaemm192_192_encrypt/128/32        1987 ns         1974 ns       352503 bytes_per_second=77.2826M/s
-schwaemm192_192_decrypt/128/32        1981 ns         1968 ns       353676 bytes_per_second=77.5358M/s
-schwaemm192_192_encrypt/256/32        2933 ns         2914 ns       239054 bytes_per_second=94.2523M/s
-schwaemm192_192_decrypt/256/32        2904 ns         2887 ns       240713 bytes_per_second=95.1495M/s
-schwaemm192_192_encrypt/512/32        5036 ns         5005 ns       135344 bytes_per_second=103.652M/s
-schwaemm192_192_decrypt/512/32        4942 ns         4916 ns       138864 bytes_per_second=105.536M/s
-schwaemm192_192_encrypt/1024/32       9025 ns         8967 ns        77680 bytes_per_second=112.312M/s
-schwaemm192_192_decrypt/1024/32       8908 ns         8811 ns        79361 bytes_per_second=114.303M/s
-schwaemm192_192_encrypt/2048/32      17531 ns        17238 ns        40490 bytes_per_second=115.077M/s
-schwaemm192_192_decrypt/2048/32      16942 ns        16712 ns        39723 bytes_per_second=118.698M/s
-schwaemm192_192_encrypt/4096/32      33152 ns        32941 ns        21284 bytes_per_second=119.508M/s
-schwaemm192_192_decrypt/4096/32      32496 ns        32305 ns        21680 bytes_per_second=121.863M/s
-schwaemm128_128_encrypt/64/32          748 ns          744 ns       910711 bytes_per_second=123.084M/s
-schwaemm128_128_decrypt/64/32          738 ns          733 ns       943422 bytes_per_second=124.846M/s
-schwaemm128_128_encrypt/128/32        1056 ns         1050 ns       659221 bytes_per_second=145.311M/s
-schwaemm128_128_decrypt/128/32        1048 ns         1042 ns       667137 bytes_per_second=146.441M/s
-schwaemm128_128_encrypt/256/32        1683 ns         1672 ns       414864 bytes_per_second=164.247M/s
-schwaemm128_128_decrypt/256/32        1668 ns         1657 ns       422198 bytes_per_second=165.762M/s
-schwaemm128_128_encrypt/512/32        2909 ns         2889 ns       239623 bytes_per_second=179.597M/s
-schwaemm128_128_decrypt/512/32        2912 ns         2891 ns       240238 bytes_per_second=179.423M/s
-schwaemm128_128_encrypt/1024/32       5393 ns         5361 ns       125956 bytes_per_second=187.836M/s
-schwaemm128_128_decrypt/1024/32       5363 ns         5331 ns       129142 bytes_per_second=188.922M/s
-schwaemm128_128_encrypt/2048/32      10375 ns        10310 ns        67231 bytes_per_second=192.406M/s
-schwaemm128_128_decrypt/2048/32      10288 ns        10221 ns        66252 bytes_per_second=194.084M/s
-schwaemm128_128_encrypt/4096/32      20238 ns        20114 ns        34536 bytes_per_second=195.722M/s
-schwaemm128_128_decrypt/4096/32      20145 ns        20024 ns        34703 bytes_per_second=196.606M/s
-schwaemm256_256_encrypt/64/32         1151 ns         1144 ns       605610 bytes_per_second=80.0282M/s
-schwaemm256_256_decrypt/64/32         1166 ns         1158 ns       600688 bytes_per_second=79.0722M/s
-schwaemm256_256_encrypt/128/32        1565 ns         1555 ns       446480 bytes_per_second=98.1174M/s
-schwaemm256_256_decrypt/128/32        1579 ns         1568 ns       437650 bytes_per_second=97.2996M/s
-schwaemm256_256_encrypt/256/32        2409 ns         2394 ns       290874 bytes_per_second=114.733M/s
-schwaemm256_256_decrypt/256/32        2426 ns         2410 ns       288443 bytes_per_second=113.982M/s
-schwaemm256_256_encrypt/512/32        4101 ns         4075 ns       171628 bytes_per_second=127.299M/s
-schwaemm256_256_decrypt/512/32        4092 ns         4065 ns       170793 bytes_per_second=127.637M/s
-schwaemm256_256_encrypt/1024/32       7503 ns         7411 ns        92228 bytes_per_second=135.89M/s
-schwaemm256_256_decrypt/1024/32       7443 ns         7396 ns        94020 bytes_per_second=136.169M/s
-schwaemm256_256_encrypt/2048/32      14186 ns        14110 ns        49035 bytes_per_second=140.589M/s
-schwaemm256_256_decrypt/2048/32      14159 ns        14076 ns        49448 bytes_per_second=140.923M/s
-schwaemm256_256_encrypt/4096/32      27583 ns        27423 ns        25349 bytes_per_second=143.555M/s
-schwaemm256_256_decrypt/4096/32      27458 ns        27304 ns        25487 bytes_per_second=144.184M/s
+esch256_hash/64                        976 ns          973 ns       673453 bytes_per_second=62.7573M/s
+esch256_hash/128                      1916 ns         1709 ns       433864 bytes_per_second=71.4076M/s
+esch256_hash/256                      3003 ns         2990 ns       235881 bytes_per_second=81.6467M/s
+esch256_hash/512                      6269 ns         5945 ns       121099 bytes_per_second=82.1263M/s
+esch256_hash/1024                    11746 ns        11649 ns        58407 bytes_per_second=83.8289M/s
+esch256_hash/2048                    23122 ns        22919 ns        30301 bytes_per_second=85.2189M/s
+esch256_hash/4096                    48235 ns        47647 ns        15792 bytes_per_second=81.9836M/s
+esch384_hash/64                       1282 ns         1278 ns       535537 bytes_per_second=47.7524M/s
+esch384_hash/128                      2228 ns         2205 ns       317092 bytes_per_second=55.3636M/s
+esch384_hash/256                      3915 ns         3873 ns       188784 bytes_per_second=63.039M/s
+esch384_hash/512                      7104 ns         7035 ns       103762 bytes_per_second=69.411M/s
+esch384_hash/1024                    13174 ns        13121 ns        50675 bytes_per_second=74.4262M/s
+esch384_hash/2048                    27419 ns        27090 ns        26228 bytes_per_second=72.0967M/s
+esch384_hash/4096                    52529 ns        52223 ns        12809 bytes_per_second=74.7998M/s
+schwaemm256_128_encrypt/64/32         1026 ns         1016 ns       703843 bytes_per_second=90.0907M/s
+schwaemm256_128_decrypt/64/32         1010 ns         1004 ns       660764 bytes_per_second=91.1863M/s
+schwaemm256_128_encrypt/128/32        1468 ns         1413 ns       491853 bytes_per_second=107.973M/s
+schwaemm256_128_decrypt/128/32        1395 ns         1381 ns       517556 bytes_per_second=110.506M/s
+schwaemm256_128_encrypt/256/32        2143 ns         2121 ns       306018 bytes_per_second=129.499M/s
+schwaemm256_128_decrypt/256/32        2034 ns         2026 ns       327564 bytes_per_second=135.551M/s
+schwaemm256_128_encrypt/512/32        3488 ns         3472 ns       205165 bytes_per_second=149.429M/s
+schwaemm256_128_decrypt/512/32        3577 ns         3535 ns       193651 bytes_per_second=146.765M/s
+schwaemm256_128_encrypt/1024/32       6207 ns         6188 ns       111231 bytes_per_second=162.734M/s
+schwaemm256_128_decrypt/1024/32       6374 ns         6306 ns       107176 bytes_per_second=159.692M/s
+schwaemm256_128_encrypt/2048/32      12223 ns        12115 ns        57263 bytes_per_second=163.731M/s
+schwaemm256_128_decrypt/2048/32      11490 ns        11451 ns        59898 bytes_per_second=173.232M/s
+schwaemm256_128_encrypt/4096/32      23329 ns        23227 ns        28865 bytes_per_second=169.489M/s
+schwaemm256_128_decrypt/4096/32      22630 ns        22582 ns        30772 bytes_per_second=174.329M/s
+schwaemm192_192_encrypt/64/32         1355 ns         1352 ns       509269 bytes_per_second=67.7147M/s
+schwaemm192_192_decrypt/64/32         1352 ns         1348 ns       515111 bytes_per_second=67.8931M/s
+schwaemm192_192_encrypt/128/32        2046 ns         2021 ns       369082 bytes_per_second=75.515M/s
+schwaemm192_192_decrypt/128/32        2063 ns         2028 ns       360758 bytes_per_second=75.2323M/s
+schwaemm192_192_encrypt/256/32        2769 ns         2762 ns       250239 bytes_per_second=99.4353M/s
+schwaemm192_192_decrypt/256/32        2714 ns         2710 ns       257102 bytes_per_second=101.342M/s
+schwaemm192_192_encrypt/512/32        5248 ns         5193 ns       100000 bytes_per_second=99.8998M/s
+schwaemm192_192_decrypt/512/32        5004 ns         4948 ns       111025 bytes_per_second=104.855M/s
+schwaemm192_192_encrypt/1024/32       8340 ns         8335 ns        79186 bytes_per_second=120.826M/s
+schwaemm192_192_decrypt/1024/32       8240 ns         8225 ns        83401 bytes_per_second=122.437M/s
+schwaemm192_192_encrypt/2048/32      16242 ns        16212 ns        42986 bytes_per_second=122.354M/s
+schwaemm192_192_decrypt/2048/32      15870 ns        15839 ns        43615 bytes_per_second=125.235M/s
+schwaemm192_192_encrypt/4096/32      33149 ns        31301 ns        22707 bytes_per_second=125.772M/s
+schwaemm192_192_decrypt/4096/32      30205 ns        30124 ns        23063 bytes_per_second=130.684M/s
+schwaemm128_128_encrypt/64/32          697 ns          696 ns       944071 bytes_per_second=131.483M/s
+schwaemm128_128_decrypt/64/32          695 ns          694 ns       990744 bytes_per_second=132.006M/s
+schwaemm128_128_encrypt/128/32         985 ns          984 ns       689546 bytes_per_second=155.124M/s
+schwaemm128_128_decrypt/128/32         974 ns          972 ns       708144 bytes_per_second=156.967M/s
+schwaemm128_128_encrypt/256/32        1558 ns         1557 ns       445712 bytes_per_second=176.388M/s
+schwaemm128_128_decrypt/256/32        1610 ns         1599 ns       399054 bytes_per_second=171.774M/s
+schwaemm128_128_encrypt/512/32        2714 ns         2710 ns       254258 bytes_per_second=191.445M/s
+schwaemm128_128_decrypt/512/32        2674 ns         2673 ns       260062 bytes_per_second=194.12M/s
+schwaemm128_128_encrypt/1024/32       5005 ns         4998 ns       134613 bytes_per_second=201.479M/s
+schwaemm128_128_decrypt/1024/32       4941 ns         4938 ns       135885 bytes_per_second=203.958M/s
+schwaemm128_128_encrypt/2048/32       9647 ns         9622 ns        71580 bytes_per_second=206.158M/s
+schwaemm128_128_decrypt/2048/32       9511 ns         9498 ns        72574 bytes_per_second=208.85M/s
+schwaemm128_128_encrypt/4096/32      18675 ns        18661 ns        36524 bytes_per_second=210.958M/s
+schwaemm128_128_decrypt/4096/32      18713 ns        18685 ns        36764 bytes_per_second=210.688M/s
+schwaemm256_256_encrypt/64/32         1077 ns         1076 ns       646138 bytes_per_second=85.1143M/s
+schwaemm256_256_decrypt/64/32         1084 ns         1083 ns       628530 bytes_per_second=84.5404M/s
+schwaemm256_256_encrypt/128/32        1469 ns         1466 ns       472973 bytes_per_second=104.049M/s
+schwaemm256_256_decrypt/128/32        1478 ns         1476 ns       466107 bytes_per_second=103.355M/s
+schwaemm256_256_encrypt/256/32        2260 ns         2258 ns       310427 bytes_per_second=121.611M/s
+schwaemm256_256_decrypt/256/32        2253 ns         2250 ns       307887 bytes_per_second=122.047M/s
+schwaemm256_256_encrypt/512/32        3815 ns         3811 ns       183769 bytes_per_second=136.136M/s
+schwaemm256_256_decrypt/512/32        3814 ns         3811 ns       184620 bytes_per_second=136.145M/s
+schwaemm256_256_encrypt/1024/32       6911 ns         6906 ns        95233 bytes_per_second=145.832M/s
+schwaemm256_256_decrypt/1024/32       6877 ns         6873 ns        98464 bytes_per_second=146.529M/s
+schwaemm256_256_encrypt/2048/32      13371 ns        13358 ns        52871 bytes_per_second=148.494M/s
+schwaemm256_256_decrypt/2048/32      13063 ns        13053 ns        52986 bytes_per_second=151.972M/s
+schwaemm256_256_encrypt/4096/32      25616 ns        25599 ns        27289 bytes_per_second=153.784M/s
+schwaemm256_256_decrypt/4096/32      25325 ns        25310 ns        27221 bytes_per_second=155.543M/s
 ```

--- a/README.md
+++ b/README.md
@@ -79,31 +79,31 @@ make benchmark
 ### On ARM Cortex-A72
 
 ```bash
-2022-05-28T12:49:22+00:00
+2022-05-30T06:53:40+00:00
 Running ./bench/a.out
 Run on (16 X 166.66 MHz CPU s)
 CPU Caches:
   L1 Data 32 KiB (x16)
   L1 Instruction 48 KiB (x16)
   L2 Unified 2048 KiB (x4)
-Load Average: 0.30, 0.07, 0.02
+Load Average: 0.24, 0.06, 0.02
 ------------------------------------------------------------------------------------------
 Benchmark                                Time             CPU   Iterations UserCounters...
 ------------------------------------------------------------------------------------------
-esch256_hash/64                        881 ns          881 ns       793925 bytes_per_second=69.2759M/s
-esch256_hash/128                      1513 ns         1513 ns       462561 bytes_per_second=80.6669M/s
-esch256_hash/256                      2763 ns         2763 ns       253359 bytes_per_second=88.3645M/s
-esch256_hash/512                      5262 ns         5262 ns       133019 bytes_per_second=92.7978M/s
-esch256_hash/1024                    10260 ns        10260 ns        68224 bytes_per_second=95.1813M/s
-esch256_hash/2048                    20257 ns        20256 ns        34556 bytes_per_second=96.4201M/s
-esch256_hash/4096                    40251 ns        40250 ns        17391 bytes_per_second=97.0487M/s
-esch384_hash/64                       2612 ns         2612 ns       267763 bytes_per_second=23.37M/s
-esch384_hash/128                      4204 ns         4204 ns       166514 bytes_per_second=29.0393M/s
-esch384_hash/256                      7383 ns         7382 ns        94815 bytes_per_second=33.0704M/s
-esch384_hash/512                     13749 ns        13749 ns        50917 bytes_per_second=35.515M/s
-esch384_hash/1024                    26468 ns        26468 ns        26446 bytes_per_second=36.8956M/s
-esch384_hash/2048                    51920 ns        51920 ns        13480 bytes_per_second=37.6179M/s
-esch384_hash/4096                   102823 ns       102822 ns         6807 bytes_per_second=37.9903M/s
+esch256_hash/64                        879 ns          879 ns       795503 bytes_per_second=69.4103M/s
+esch256_hash/128                      1488 ns         1488 ns       470565 bytes_per_second=82.0615M/s
+esch256_hash/256                      2688 ns         2688 ns       260377 bytes_per_second=90.8133M/s
+esch256_hash/512                      5090 ns         5090 ns       137514 bytes_per_second=95.9297M/s
+esch256_hash/1024                     9894 ns         9894 ns        70748 bytes_per_second=98.707M/s
+esch256_hash/2048                    19500 ns        19500 ns        35896 bytes_per_second=100.162M/s
+esch256_hash/4096                    38714 ns        38714 ns        18081 bytes_per_second=100.901M/s
+esch384_hash/64                       2582 ns         2582 ns       271343 bytes_per_second=23.6355M/s
+esch384_hash/128                      4132 ns         4132 ns       169413 bytes_per_second=29.5435M/s
+esch384_hash/256                      7240 ns         7240 ns        96685 bytes_per_second=33.7211M/s
+esch384_hash/512                     13457 ns        13457 ns        52016 bytes_per_second=36.285M/s
+esch384_hash/1024                    25895 ns        25894 ns        27031 bytes_per_second=37.7133M/s
+esch384_hash/2048                    50761 ns        50761 ns        13790 bytes_per_second=38.4771M/s
+esch384_hash/4096                   100497 ns       100495 ns         6965 bytes_per_second=38.8701M/s
 schwaemm256_128_encrypt/64/32         1189 ns         1189 ns       588654 bytes_per_second=76.9925M/s
 schwaemm256_128_decrypt/64/32         1192 ns         1192 ns       587163 bytes_per_second=76.7918M/s
 schwaemm256_128_encrypt/128/32        1634 ns         1634 ns       428609 bytes_per_second=93.4006M/s
@@ -165,7 +165,7 @@ schwaemm256_256_decrypt/4096/32      55611 ns        55610 ns        12587 bytes
 ### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
 
 ```bash
-2022-05-28T16:44:26+04:00
+2022-05-30T10:50:00+04:00
 Running ./bench/a.out
 Run on (8 X 2400 MHz CPU s)
 CPU Caches:
@@ -173,24 +173,24 @@ CPU Caches:
   L1 Instruction 32 KiB
   L2 Unified 256 KiB (x4)
   L3 Unified 6144 KiB
-Load Average: 3.13, 3.46, 3.10
+Load Average: 5.22, 4.73, 3.97
 ------------------------------------------------------------------------------------------
 Benchmark                                Time             CPU   Iterations UserCounters...
 ------------------------------------------------------------------------------------------
-esch256_hash/64                       1117 ns         1036 ns       683500 bytes_per_second=58.9166M/s
-esch256_hash/128                      1785 ns         1761 ns       401712 bytes_per_second=69.3208M/s
-esch256_hash/256                      3254 ns         3216 ns       217531 bytes_per_second=75.9241M/s
-esch256_hash/512                      6217 ns         6141 ns       115986 bytes_per_second=79.5092M/s
-esch256_hash/1024                    12041 ns        11951 ns        58297 bytes_per_second=81.7153M/s
-esch256_hash/2048                    23785 ns        23579 ns        29391 bytes_per_second=82.8336M/s
-esch256_hash/4096                    47793 ns        47245 ns        15017 bytes_per_second=82.6803M/s
-esch384_hash/64                       1395 ns         1379 ns       502004 bytes_per_second=44.2687M/s
-esch384_hash/128                      2243 ns         2220 ns       316595 bytes_per_second=54.9959M/s
-esch384_hash/256                      4137 ns         4059 ns       176567 bytes_per_second=60.1463M/s
-esch384_hash/512                      7833 ns         7706 ns        96751 bytes_per_second=63.3623M/s
-esch384_hash/1024                    14619 ns        14396 ns        35221 bytes_per_second=67.8349M/s
-esch384_hash/2048                    28334 ns        28079 ns        25199 bytes_per_second=69.5574M/s
-esch384_hash/4096                    55606 ns        55035 ns        12673 bytes_per_second=70.9778M/s
+esch256_hash/64                       1019 ns         1009 ns       683267 bytes_per_second=60.5206M/s
+esch256_hash/128                      1887 ns         1843 ns       374006 bytes_per_second=66.2434M/s
+esch256_hash/256                      3198 ns         3168 ns       212928 bytes_per_second=77.0606M/s
+esch256_hash/512                      6063 ns         6007 ns       117615 bytes_per_second=81.289M/s
+esch256_hash/1024                    11574 ns        11525 ns        59160 bytes_per_second=84.732M/s
+esch256_hash/2048                    23485 ns        23226 ns        30223 bytes_per_second=84.091M/s
+esch256_hash/4096                    45179 ns        45043 ns        15307 bytes_per_second=86.7233M/s
+esch384_hash/64                       1349 ns         1340 ns       529942 bytes_per_second=45.5352M/s
+esch384_hash/128                      2225 ns         2202 ns       317255 bytes_per_second=55.4412M/s
+esch384_hash/256                      4440 ns         4285 ns       178355 bytes_per_second=56.9771M/s
+esch384_hash/512                      8052 ns         7495 ns        96360 bytes_per_second=65.1486M/s
+esch384_hash/1024                    13690 ns        13624 ns        47993 bytes_per_second=71.679M/s
+esch384_hash/2048                    27788 ns        27475 ns        25713 bytes_per_second=71.0878M/s
+esch384_hash/4096                    55963 ns        55129 ns        13309 bytes_per_second=70.8571M/s
 schwaemm256_128_encrypt/64/32         1075 ns         1063 ns       644995 bytes_per_second=86.1231M/s
 schwaemm256_128_decrypt/64/32         1087 ns         1074 ns       654132 bytes_per_second=85.2757M/s
 schwaemm256_128_encrypt/128/32        1463 ns         1448 ns       473966 bytes_per_second=105.366M/s

--- a/include/esch384.hpp
+++ b/include/esch384.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "hash.hpp"
+#include "utils.hpp"
 #include <cstring>
 
 // Esch384 hash function, based on Sparkle permutation
@@ -34,18 +35,22 @@ hash(const uint8_t* const __restrict in, // input message
 
     std::memset(buffer + 4, 0, 16);
 
+    if constexpr (is_little_endian()) {
+      std::memcpy(buffer, in + b_off, hash::RATE);
+    } else {
 #if defined __clang__
 #pragma unroll 4
 #elif defined __GNUG__
 #pragma GCC unroll 4
 #endif
-    for (size_t j = 0; j < 4; j++) {
-      const size_t i_off = j << 2;
+      for (size_t j = 0; j < 4; j++) {
+        const size_t i_off = j << 2;
 
-      buffer[j] = (static_cast<uint32_t>(in[b_off + (i_off ^ 3)]) << 24) |
-                  (static_cast<uint32_t>(in[b_off + (i_off ^ 2)]) << 16) |
-                  (static_cast<uint32_t>(in[b_off + (i_off ^ 1)]) << 8) |
-                  (static_cast<uint32_t>(in[b_off + (i_off ^ 0)]) << 0);
+        buffer[j] = (static_cast<uint32_t>(in[b_off + (i_off ^ 3)]) << 24) |
+                    (static_cast<uint32_t>(in[b_off + (i_off ^ 2)]) << 16) |
+                    (static_cast<uint32_t>(in[b_off + (i_off ^ 1)]) << 8) |
+                    (static_cast<uint32_t>(in[b_off + (i_off ^ 0)]) << 0);
+      }
     }
 
     hash::feistel<512ul>(state, buffer);
@@ -60,13 +65,17 @@ hash(const uint8_t* const __restrict in, // input message
 
   std::memset(buffer, 0, 32);
 
-  for (size_t i = 0; i < rb_full_words; i++) {
-    const size_t off = i << 2;
+  if constexpr (is_little_endian()) {
+    std::memcpy(buffer, in + b_off, rb_full_words << 2);
+  } else {
+    for (size_t i = 0; i < rb_full_words; i++) {
+      const size_t off = i << 2;
 
-    buffer[i] = (static_cast<uint32_t>(in[b_off + (off ^ 3)]) << 24) |
-                (static_cast<uint32_t>(in[b_off + (off ^ 2)]) << 16) |
-                (static_cast<uint32_t>(in[b_off + (off ^ 1)]) << 8) |
-                (static_cast<uint32_t>(in[b_off + (off ^ 0)]) << 0);
+      buffer[i] = (static_cast<uint32_t>(in[b_off + (off ^ 3)]) << 24) |
+                  (static_cast<uint32_t>(in[b_off + (off ^ 2)]) << 16) |
+                  (static_cast<uint32_t>(in[b_off + (off ^ 1)]) << 8) |
+                  (static_cast<uint32_t>(in[b_off + (off ^ 0)]) << 0);
+    }
   }
 
   uint32_t word = 0x80u << (rb_rem_bytes << 3);
@@ -85,53 +94,65 @@ hash(const uint8_t* const __restrict in, // input message
   hash::feistel<512ul>(state, buffer);
   sparkle::sparkle<8ul, 12ul>(state);
 
+  if constexpr (is_little_endian()) {
+    std::memcpy(out, state, hash::RATE);
+  } else {
 #if defined __clang__
 #pragma unroll 4
 #elif defined __GNUG__
 #pragma GCC unroll 4
 #endif
-  for (size_t i = 0; i < 4; i++) {
-    const uint32_t word = state[i];
-    const size_t b_off = i << 2;
+    for (size_t i = 0; i < 4; i++) {
+      const uint32_t word = state[i];
+      const size_t b_off = i << 2;
 
-    out[b_off ^ 0] = static_cast<uint8_t>(word >> 0);
-    out[b_off ^ 1] = static_cast<uint8_t>(word >> 8);
-    out[b_off ^ 2] = static_cast<uint8_t>(word >> 16);
-    out[b_off ^ 3] = static_cast<uint8_t>(word >> 24);
+      out[b_off ^ 0] = static_cast<uint8_t>(word >> 0);
+      out[b_off ^ 1] = static_cast<uint8_t>(word >> 8);
+      out[b_off ^ 2] = static_cast<uint8_t>(word >> 16);
+      out[b_off ^ 3] = static_cast<uint8_t>(word >> 24);
+    }
   }
 
   sparkle::sparkle<8ul, 8ul>(state);
 
+  if constexpr (is_little_endian()) {
+    std::memcpy(out + hash::RATE, state, hash::RATE);
+  } else {
 #if defined __clang__
 #pragma unroll 4
 #elif defined __GNUG__
 #pragma GCC unroll 4
 #endif
-  for (size_t i = 0; i < 4; i++) {
-    const uint32_t word = state[i];
-    const size_t b_off = i << 2;
+    for (size_t i = 0; i < 4; i++) {
+      const uint32_t word = state[i];
+      const size_t b_off = i << 2;
 
-    out[16ul + (b_off ^ 0)] = static_cast<uint8_t>(word >> 0);
-    out[16ul + (b_off ^ 1)] = static_cast<uint8_t>(word >> 8);
-    out[16ul + (b_off ^ 2)] = static_cast<uint8_t>(word >> 16);
-    out[16ul + (b_off ^ 3)] = static_cast<uint8_t>(word >> 24);
+      out[16ul + (b_off ^ 0)] = static_cast<uint8_t>(word >> 0);
+      out[16ul + (b_off ^ 1)] = static_cast<uint8_t>(word >> 8);
+      out[16ul + (b_off ^ 2)] = static_cast<uint8_t>(word >> 16);
+      out[16ul + (b_off ^ 3)] = static_cast<uint8_t>(word >> 24);
+    }
   }
 
   sparkle::sparkle<8ul, 8ul>(state);
 
+  if constexpr (is_little_endian()) {
+    std::memcpy(out + (hash::RATE << 1), state, hash::RATE);
+  } else {
 #if defined __clang__
 #pragma unroll 4
 #elif defined __GNUG__
 #pragma GCC unroll 4
 #endif
-  for (size_t i = 0; i < 4; i++) {
-    const uint32_t word = state[i];
-    const size_t b_off = i << 2;
+    for (size_t i = 0; i < 4; i++) {
+      const uint32_t word = state[i];
+      const size_t b_off = i << 2;
 
-    out[32ul + (b_off ^ 0)] = static_cast<uint8_t>(word >> 0);
-    out[32ul + (b_off ^ 1)] = static_cast<uint8_t>(word >> 8);
-    out[32ul + (b_off ^ 2)] = static_cast<uint8_t>(word >> 16);
-    out[32ul + (b_off ^ 3)] = static_cast<uint8_t>(word >> 24);
+      out[32ul + (b_off ^ 0)] = static_cast<uint8_t>(word >> 0);
+      out[32ul + (b_off ^ 1)] = static_cast<uint8_t>(word >> 8);
+      out[32ul + (b_off ^ 2)] = static_cast<uint8_t>(word >> 16);
+      out[32ul + (b_off ^ 3)] = static_cast<uint8_t>(word >> 24);
+    }
   }
 }
 

--- a/include/schwaemm256_128.hpp
+++ b/include/schwaemm256_128.hpp
@@ -1,9 +1,16 @@
 #pragma once
 #include "sparkle.hpp"
+#include "utils.hpp"
 #include <cstring>
 
 // Schwaemm256-128 Authenticated Encryption with Associated Data ( AEAD ) Scheme
 namespace schwaemm256_128 {
+
+// These many bytes are consumed into permutation state, in every iteration
+constexpr size_t RATE = 32;
+
+// These many 32 -bit words are present in rate width of permutation
+constexpr size_t RATE_W = RATE >> 2;
 
 // To distinguish padded associated data block from non-padded one, this
 // constant is XORed into inner part of permutation state, when processing last
@@ -37,22 +44,40 @@ initialize(uint32_t* const __restrict state,     // 384 -bit permutation state
            const uint8_t* const __restrict nonce // 32 -bytes nonce
 )
 {
-  for (size_t i = 0; i < 8; i++) {
-    const size_t b_off = i << 2;
+  if constexpr (is_little_endian()) {
+    std::memcpy(state, nonce, RATE);
+  } else {
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+    for (size_t i = 0; i < 8; i++) {
+      const size_t b_off = i << 2;
 
-    state[i] = (static_cast<uint32_t>(nonce[b_off ^ 3]) << 24) |
-               (static_cast<uint32_t>(nonce[b_off ^ 2]) << 16) |
-               (static_cast<uint32_t>(nonce[b_off ^ 1]) << 8) |
-               (static_cast<uint32_t>(nonce[b_off ^ 0]) << 0);
+      state[i] = (static_cast<uint32_t>(nonce[b_off ^ 3]) << 24) |
+                 (static_cast<uint32_t>(nonce[b_off ^ 2]) << 16) |
+                 (static_cast<uint32_t>(nonce[b_off ^ 1]) << 8) |
+                 (static_cast<uint32_t>(nonce[b_off ^ 0]) << 0);
+    }
   }
 
-  for (size_t i = 0; i < 4; i++) {
-    const size_t b_off = i << 2;
+  if constexpr (is_little_endian()) {
+    std::memcpy(state + RATE_W, key, RATE >> 1);
+  } else {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+    for (size_t i = 0; i < 4; i++) {
+      const size_t b_off = i << 2;
 
-    state[8ul ^ i] = (static_cast<uint32_t>(key[b_off ^ 3]) << 24) |
-                     (static_cast<uint32_t>(key[b_off ^ 2]) << 16) |
-                     (static_cast<uint32_t>(key[b_off ^ 1]) << 8) |
-                     (static_cast<uint32_t>(key[b_off ^ 0]) << 0);
+      state[8ul ^ i] = (static_cast<uint32_t>(key[b_off ^ 3]) << 24) |
+                       (static_cast<uint32_t>(key[b_off ^ 2]) << 16) |
+                       (static_cast<uint32_t>(key[b_off ^ 1]) << 8) |
+                       (static_cast<uint32_t>(key[b_off ^ 0]) << 0);
+    }
   }
 
   sparkle::sparkle<6ul, 11ul>(state);
@@ -94,7 +119,12 @@ rho1(uint32_t* const __restrict s,      // 256 -bit
 {
   feistel_swap(s);
 
-  for (size_t i = 0; i < 8; i++) {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
     s[i] ^= d[i];
   }
 }
@@ -108,7 +138,12 @@ rho2(uint32_t* const __restrict s,      // 256 -bit
      const uint32_t* const __restrict d // 256 -bit
 )
 {
-  for (size_t i = 0; i < 8; i++) {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
     s[i] ^= d[i];
   }
 }
@@ -123,12 +158,17 @@ rhoprime1(uint32_t* const __restrict s,      // 256 -bit
           const uint32_t* const __restrict d // 256 -bit
 )
 {
-  uint32_t s_[8];
-  std::memcpy(s_, s, 32);
+  uint32_t s_[RATE_W];
+  std::memcpy(s_, s, RATE);
 
   feistel_swap(s);
 
-  for (size_t i = 0; i < 8; i++) {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
     s[i] ^= s_[i] ^ d[i];
   }
 }
@@ -143,7 +183,12 @@ rhoprime2(uint32_t* const __restrict s,      // 256 -bit
           const uint32_t* const __restrict d // 256 -bit
 )
 {
-  for (size_t i = 0; i < 8; i++) {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
     s[i] ^= d[i];
   }
 }
@@ -154,8 +199,10 @@ omega(const uint32_t* const __restrict in, // 128 -bit
       uint32_t* const __restrict out       // 256 -bit
 )
 {
-  std::memcpy(out + 0, in, 16);
-  std::memcpy(out + 4, in, 16);
+  constexpr size_t bytes = RATE >> 1;
+
+  std::memcpy(out + 0, in, bytes);
+  std::memcpy(out + 4, in, bytes);
 }
 
 // Consumes non-empty associated data into 384 -bit permutation state using
@@ -168,28 +215,40 @@ process_associated_data(
   const size_t d_len                    // len(data) = N -bytes | N > 0
 )
 {
-  constexpr size_t RATE = 32; // bytes
-
-  uint32_t buffer0[9];
-  uint32_t buffer1[8];
+  uint32_t buffer0[RATE_W ^ 1];
+  uint32_t buffer1[RATE_W];
 
   size_t r_bytes = d_len;
   while (r_bytes > RATE) {
     const size_t b_off = d_len - r_bytes;
 
-    for (size_t i = 0; i < (RATE >> 2); i++) {
-      const size_t i_off = i << 2;
+    if constexpr (is_little_endian()) {
+      std::memcpy(buffer0, data + b_off, RATE);
+    } else {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+      for (size_t i = 0; i < RATE_W; i++) {
+        const size_t i_off = i << 2;
 
-      buffer0[i] = (static_cast<uint32_t>(data[b_off + (i_off ^ 3)]) << 24) |
-                   (static_cast<uint32_t>(data[b_off + (i_off ^ 2)]) << 16) |
-                   (static_cast<uint32_t>(data[b_off + (i_off ^ 1)]) << 8) |
-                   (static_cast<uint32_t>(data[b_off + (i_off ^ 0)]) << 0);
+        buffer0[i] = (static_cast<uint32_t>(data[b_off + (i_off ^ 3)]) << 24) |
+                     (static_cast<uint32_t>(data[b_off + (i_off ^ 2)]) << 16) |
+                     (static_cast<uint32_t>(data[b_off + (i_off ^ 1)]) << 8) |
+                     (static_cast<uint32_t>(data[b_off + (i_off ^ 0)]) << 0);
+      }
     }
 
     rho1(state, buffer0);
-    omega(state + 8, buffer1);
+    omega(state + RATE_W, buffer1);
 
-    for (size_t i = 0; i < (RATE >> 2); i++) {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+    for (size_t i = 0; i < RATE_W; i++) {
       state[i] ^= buffer1[i];
     }
 
@@ -204,13 +263,17 @@ process_associated_data(
 
   std::memset(buffer0, 0, RATE);
 
-  for (size_t i = 0; i < rb_full_words; i++) {
-    const size_t off = i << 2;
+  if constexpr (is_little_endian()) {
+    std::memcpy(buffer0, data + b_off, rb_full_words << 2);
+  } else {
+    for (size_t i = 0; i < rb_full_words; i++) {
+      const size_t off = i << 2;
 
-    buffer0[i] = (static_cast<uint32_t>(data[b_off + (off ^ 3)]) << 24) |
-                 (static_cast<uint32_t>(data[b_off + (off ^ 2)]) << 16) |
-                 (static_cast<uint32_t>(data[b_off + (off ^ 1)]) << 8) |
-                 (static_cast<uint32_t>(data[b_off + (off ^ 0)]) << 0);
+      buffer0[i] = (static_cast<uint32_t>(data[b_off + (off ^ 3)]) << 24) |
+                   (static_cast<uint32_t>(data[b_off + (off ^ 2)]) << 16) |
+                   (static_cast<uint32_t>(data[b_off + (off ^ 1)]) << 8) |
+                   (static_cast<uint32_t>(data[b_off + (off ^ 0)]) << 0);
+    }
   }
 
   uint32_t word = 0x80u << (rb_rem_bytes << 3);
@@ -221,16 +284,21 @@ process_associated_data(
   }
 
   const uint32_t words[2] = { 0u, word };
-  buffer0[rb_full_words] = words[rb_full_words < 8];
+  buffer0[rb_full_words] = words[rb_full_words < RATE_W];
 
   rho1(state, buffer0);
 
   constexpr uint32_t consts[2] = { CONST_A1, CONST_A0 };
-  state[11] ^= consts[rb_full_words < 8];
+  state[11] ^= consts[rb_full_words < RATE_W];
 
-  omega(state + 8, buffer1);
+  omega(state + RATE_W, buffer1);
 
-  for (size_t i = 0; i < (RATE >> 2); i++) {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
     state[i] ^= buffer1[i];
   }
 
@@ -249,41 +317,62 @@ process_plain_text(
   const size_t ct_len                  // len(txt) = len(enc) = N | N > 0
 )
 {
-  constexpr size_t RATE = 32; // bytes
-
-  uint32_t buffer0[9];
-  uint32_t buffer1[8];
-  uint32_t buffer2[8];
+  uint32_t buffer0[RATE_W ^ 1];
+  uint32_t buffer1[RATE_W];
+  uint32_t buffer2[RATE_W];
 
   size_t r_bytes = ct_len;
   while (r_bytes > RATE) {
     const size_t b_off = ct_len - r_bytes;
 
-    for (size_t i = 0; i < (RATE >> 2); i++) {
-      const size_t i_off = i << 2;
+    if constexpr (is_little_endian()) {
+      std::memcpy(buffer0, txt + b_off, RATE);
+    } else {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+      for (size_t i = 0; i < RATE_W; i++) {
+        const size_t i_off = i << 2;
 
-      buffer0[i] = (static_cast<uint32_t>(txt[b_off + (i_off ^ 3)]) << 24) |
-                   (static_cast<uint32_t>(txt[b_off + (i_off ^ 2)]) << 16) |
-                   (static_cast<uint32_t>(txt[b_off + (i_off ^ 1)]) << 8) |
-                   (static_cast<uint32_t>(txt[b_off + (i_off ^ 0)]) << 0);
+        buffer0[i] = (static_cast<uint32_t>(txt[b_off + (i_off ^ 3)]) << 24) |
+                     (static_cast<uint32_t>(txt[b_off + (i_off ^ 2)]) << 16) |
+                     (static_cast<uint32_t>(txt[b_off + (i_off ^ 1)]) << 8) |
+                     (static_cast<uint32_t>(txt[b_off + (i_off ^ 0)]) << 0);
+      }
     }
 
     std::memcpy(buffer2, state, RATE);
     rho2(buffer2, buffer0);
 
-    for (size_t i = 0; i < (RATE >> 2); i++) {
-      const size_t i_off = i << 2;
+    if constexpr (is_little_endian()) {
+      std::memcpy(enc + b_off, buffer2, RATE);
+    } else {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+      for (size_t i = 0; i < RATE_W; i++) {
+        const size_t i_off = i << 2;
 
-      enc[b_off + (i_off ^ 0)] = static_cast<uint8_t>(buffer2[i] >> 0);
-      enc[b_off + (i_off ^ 1)] = static_cast<uint8_t>(buffer2[i] >> 8);
-      enc[b_off + (i_off ^ 2)] = static_cast<uint8_t>(buffer2[i] >> 16);
-      enc[b_off + (i_off ^ 3)] = static_cast<uint8_t>(buffer2[i] >> 24);
+        enc[b_off + (i_off ^ 0)] = static_cast<uint8_t>(buffer2[i] >> 0);
+        enc[b_off + (i_off ^ 1)] = static_cast<uint8_t>(buffer2[i] >> 8);
+        enc[b_off + (i_off ^ 2)] = static_cast<uint8_t>(buffer2[i] >> 16);
+        enc[b_off + (i_off ^ 3)] = static_cast<uint8_t>(buffer2[i] >> 24);
+      }
     }
 
     rho1(state, buffer0);
-    omega(state + 8, buffer1);
+    omega(state + RATE_W, buffer1);
 
-    for (size_t i = 0; i < (RATE >> 2); i++) {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+    for (size_t i = 0; i < RATE_W; i++) {
       state[i] ^= buffer1[i];
     }
 
@@ -299,13 +388,17 @@ process_plain_text(
 
   std::memset(buffer0, 0, RATE);
 
-  for (size_t i = 0; i < rb_full_words; i++) {
-    const size_t i_off = i << 2;
+  if constexpr (is_little_endian()) {
+    std::memcpy(buffer0, txt + b_off, rb_full_words << 2);
+  } else {
+    for (size_t i = 0; i < rb_full_words; i++) {
+      const size_t i_off = i << 2;
 
-    buffer0[i] = (static_cast<uint32_t>(txt[b_off + (i_off ^ 3)]) << 24) |
-                 (static_cast<uint32_t>(txt[b_off + (i_off ^ 2)]) << 16) |
-                 (static_cast<uint32_t>(txt[b_off + (i_off ^ 1)]) << 8) |
-                 (static_cast<uint32_t>(txt[b_off + (i_off ^ 0)]) << 0);
+      buffer0[i] = (static_cast<uint32_t>(txt[b_off + (i_off ^ 3)]) << 24) |
+                   (static_cast<uint32_t>(txt[b_off + (i_off ^ 2)]) << 16) |
+                   (static_cast<uint32_t>(txt[b_off + (i_off ^ 1)]) << 8) |
+                   (static_cast<uint32_t>(txt[b_off + (i_off ^ 0)]) << 0);
+    }
   }
 
   uint32_t word = 0x80u << (rb_rem_bytes << 3);
@@ -316,18 +409,22 @@ process_plain_text(
   }
 
   const uint32_t words[2] = { 0u, word };
-  buffer0[rb_full_words] = words[rb_full_words < 8];
+  buffer0[rb_full_words] = words[rb_full_words < RATE_W];
 
   std::memcpy(buffer2, state, RATE);
   rho2(buffer2, buffer0);
 
-  for (size_t i = 0; i < rb_full_words; i++) {
-    const size_t i_off = i << 2;
+  if constexpr (is_little_endian()) {
+    std::memcpy(enc + b_off, buffer2, rb_full_words << 2);
+  } else {
+    for (size_t i = 0; i < rb_full_words; i++) {
+      const size_t i_off = i << 2;
 
-    enc[b_off + (i_off ^ 0)] = static_cast<uint8_t>(buffer2[i] >> 0);
-    enc[b_off + (i_off ^ 1)] = static_cast<uint8_t>(buffer2[i] >> 8);
-    enc[b_off + (i_off ^ 2)] = static_cast<uint8_t>(buffer2[i] >> 16);
-    enc[b_off + (i_off ^ 3)] = static_cast<uint8_t>(buffer2[i] >> 24);
+      enc[b_off + (i_off ^ 0)] = static_cast<uint8_t>(buffer2[i] >> 0);
+      enc[b_off + (i_off ^ 1)] = static_cast<uint8_t>(buffer2[i] >> 8);
+      enc[b_off + (i_off ^ 2)] = static_cast<uint8_t>(buffer2[i] >> 16);
+      enc[b_off + (i_off ^ 3)] = static_cast<uint8_t>(buffer2[i] >> 24);
+    }
   }
 
   for (size_t i = 0; i < rb_rem_bytes; i++) {
@@ -339,11 +436,16 @@ process_plain_text(
   rho1(state, buffer0);
 
   constexpr uint32_t consts[2] = { CONST_M1, CONST_M0 };
-  state[11] ^= consts[rb_full_words < 8];
+  state[11] ^= consts[rb_full_words < RATE_W];
 
-  omega(state + 8, buffer1);
+  omega(state + RATE_W, buffer1);
 
-  for (size_t i = 0; i < (RATE >> 2); i++) {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
     state[i] ^= buffer1[i];
   }
 
@@ -362,41 +464,62 @@ process_cipher_text(
   const size_t ct_len                  // len(enc) = len(dec) = N | N > 0
 )
 {
-  constexpr size_t RATE = 32; // bytes
-
-  uint32_t buffer0[9];
-  uint32_t buffer1[8];
-  uint32_t buffer2[8];
+  uint32_t buffer0[RATE_W ^ 1];
+  uint32_t buffer1[RATE_W];
+  uint32_t buffer2[RATE_W];
 
   size_t r_bytes = ct_len;
   while (r_bytes > RATE) {
     const size_t b_off = ct_len - r_bytes;
 
-    for (size_t i = 0; i < (RATE >> 2); i++) {
-      const size_t i_off = i << 2;
+    if constexpr (is_little_endian()) {
+      std::memcpy(buffer0, enc + b_off, RATE);
+    } else {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+      for (size_t i = 0; i < RATE_W; i++) {
+        const size_t i_off = i << 2;
 
-      buffer0[i] = (static_cast<uint32_t>(enc[b_off + (i_off ^ 3)]) << 24) |
-                   (static_cast<uint32_t>(enc[b_off + (i_off ^ 2)]) << 16) |
-                   (static_cast<uint32_t>(enc[b_off + (i_off ^ 1)]) << 8) |
-                   (static_cast<uint32_t>(enc[b_off + (i_off ^ 0)]) << 0);
+        buffer0[i] = (static_cast<uint32_t>(enc[b_off + (i_off ^ 3)]) << 24) |
+                     (static_cast<uint32_t>(enc[b_off + (i_off ^ 2)]) << 16) |
+                     (static_cast<uint32_t>(enc[b_off + (i_off ^ 1)]) << 8) |
+                     (static_cast<uint32_t>(enc[b_off + (i_off ^ 0)]) << 0);
+      }
     }
 
     std::memcpy(buffer2, state, RATE);
     rhoprime2(buffer2, buffer0);
 
-    for (size_t i = 0; i < (RATE >> 2); i++) {
-      const size_t i_off = i << 2;
+    if constexpr (is_little_endian()) {
+      std::memcpy(dec + b_off, buffer2, RATE);
+    } else {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+      for (size_t i = 0; i < RATE_W; i++) {
+        const size_t i_off = i << 2;
 
-      dec[b_off + (i_off ^ 0)] = static_cast<uint8_t>(buffer2[i] >> 0);
-      dec[b_off + (i_off ^ 1)] = static_cast<uint8_t>(buffer2[i] >> 8);
-      dec[b_off + (i_off ^ 2)] = static_cast<uint8_t>(buffer2[i] >> 16);
-      dec[b_off + (i_off ^ 3)] = static_cast<uint8_t>(buffer2[i] >> 24);
+        dec[b_off + (i_off ^ 0)] = static_cast<uint8_t>(buffer2[i] >> 0);
+        dec[b_off + (i_off ^ 1)] = static_cast<uint8_t>(buffer2[i] >> 8);
+        dec[b_off + (i_off ^ 2)] = static_cast<uint8_t>(buffer2[i] >> 16);
+        dec[b_off + (i_off ^ 3)] = static_cast<uint8_t>(buffer2[i] >> 24);
+      }
     }
 
     rhoprime1(state, buffer0);
-    omega(state + 8, buffer1);
+    omega(state + RATE_W, buffer1);
 
-    for (size_t i = 0; i < (RATE >> 2); i++) {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+    for (size_t i = 0; i < RATE_W; i++) {
       state[i] ^= buffer1[i];
     }
 
@@ -412,13 +535,17 @@ process_cipher_text(
 
   std::memset(buffer0, 0, RATE);
 
-  for (size_t i = 0; i < rb_full_words; i++) {
-    const size_t i_off = i << 2;
+  if constexpr (is_little_endian()) {
+    std::memcpy(buffer0, enc + b_off, rb_full_words << 2);
+  } else {
+    for (size_t i = 0; i < rb_full_words; i++) {
+      const size_t i_off = i << 2;
 
-    buffer0[i] = (static_cast<uint32_t>(enc[b_off + (i_off ^ 3)]) << 24) |
-                 (static_cast<uint32_t>(enc[b_off + (i_off ^ 2)]) << 16) |
-                 (static_cast<uint32_t>(enc[b_off + (i_off ^ 1)]) << 8) |
-                 (static_cast<uint32_t>(enc[b_off + (i_off ^ 0)]) << 0);
+      buffer0[i] = (static_cast<uint32_t>(enc[b_off + (i_off ^ 3)]) << 24) |
+                   (static_cast<uint32_t>(enc[b_off + (i_off ^ 2)]) << 16) |
+                   (static_cast<uint32_t>(enc[b_off + (i_off ^ 1)]) << 8) |
+                   (static_cast<uint32_t>(enc[b_off + (i_off ^ 0)]) << 0);
+    }
   }
 
   uint32_t word = 0x80u << (rb_rem_bytes << 3);
@@ -429,18 +556,22 @@ process_cipher_text(
   }
 
   const uint32_t words[2] = { 0u, word };
-  buffer0[rb_full_words] = words[rb_full_words < 8];
+  buffer0[rb_full_words] = words[rb_full_words < RATE_W];
 
   std::memcpy(buffer2, state, RATE);
   rhoprime2(buffer2, buffer0);
 
-  for (size_t i = 0; i < rb_full_words; i++) {
-    const size_t i_off = i << 2;
+  if constexpr (is_little_endian()) {
+    std::memcpy(dec + b_off, buffer2, rb_full_words << 2);
+  } else {
+    for (size_t i = 0; i < rb_full_words; i++) {
+      const size_t i_off = i << 2;
 
-    dec[b_off + (i_off ^ 0)] = static_cast<uint8_t>(buffer2[i] >> 0);
-    dec[b_off + (i_off ^ 1)] = static_cast<uint8_t>(buffer2[i] >> 8);
-    dec[b_off + (i_off ^ 2)] = static_cast<uint8_t>(buffer2[i] >> 16);
-    dec[b_off + (i_off ^ 3)] = static_cast<uint8_t>(buffer2[i] >> 24);
+      dec[b_off + (i_off ^ 0)] = static_cast<uint8_t>(buffer2[i] >> 0);
+      dec[b_off + (i_off ^ 1)] = static_cast<uint8_t>(buffer2[i] >> 8);
+      dec[b_off + (i_off ^ 2)] = static_cast<uint8_t>(buffer2[i] >> 16);
+      dec[b_off + (i_off ^ 3)] = static_cast<uint8_t>(buffer2[i] >> 24);
+    }
   }
 
   for (size_t i = 0; i < rb_rem_bytes; i++) {
@@ -468,11 +599,16 @@ process_cipher_text(
   }
 
   constexpr uint32_t consts[2] = { CONST_M1, CONST_M0 };
-  state[11] ^= consts[rb_full_words < 8];
+  state[11] ^= consts[rb_full_words < RATE_W];
 
-  omega(state + 8, buffer1);
+  omega(state + RATE_W, buffer1);
 
-  for (size_t i = 0; i < (RATE >> 2); i++) {
+#if defined __clang__
+#pragma unroll 8
+#elif defined __GNUG__
+#pragma GCC unroll 8
+#endif
+  for (size_t i = 0; i < RATE_W; i++) {
     state[i] ^= buffer1[i];
   }
 
@@ -491,25 +627,55 @@ finalize(
   uint8_t* const __restrict tag           // 16 -bytes authentication tag
 )
 {
-  uint32_t buffer[4];
+  constexpr size_t words = RATE_W >> 1;
+  constexpr size_t words_b = words << 2;
 
-  for (size_t i = 0; i < 4; i++) {
-    const size_t b_off = i << 2;
+  uint32_t buffer[words];
 
-    buffer[i] = (static_cast<uint32_t>(key[b_off ^ 3]) << 24) |
-                (static_cast<uint32_t>(key[b_off ^ 2]) << 16) |
-                (static_cast<uint32_t>(key[b_off ^ 1]) << 8) |
-                (static_cast<uint32_t>(key[b_off ^ 0]) << 0);
+  if constexpr (is_little_endian()) {
+    std::memcpy(buffer, key, words_b);
+  } else {
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+    for (size_t i = 0; i < words; i++) {
+      const size_t b_off = i << 2;
+
+      buffer[i] = (static_cast<uint32_t>(key[b_off ^ 3]) << 24) |
+                  (static_cast<uint32_t>(key[b_off ^ 2]) << 16) |
+                  (static_cast<uint32_t>(key[b_off ^ 1]) << 8) |
+                  (static_cast<uint32_t>(key[b_off ^ 0]) << 0);
+    }
   }
 
-  for (size_t i = 0; i < 4; i++) {
-    const size_t b_off = i << 2;
-    const uint32_t t_word = state[8ul ^ i] ^ buffer[i];
+  if constexpr (is_little_endian()) {
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+    for (size_t i = 0; i < words; i++) {
+      buffer[i] ^= state[RATE_W ^ i];
+    }
 
-    tag[b_off ^ 0] = static_cast<uint8_t>(t_word >> 0);
-    tag[b_off ^ 1] = static_cast<uint8_t>(t_word >> 8);
-    tag[b_off ^ 2] = static_cast<uint8_t>(t_word >> 16);
-    tag[b_off ^ 3] = static_cast<uint8_t>(t_word >> 24);
+    std::memcpy(tag, buffer, words_b);
+  } else {
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC unroll 4
+#endif
+    for (size_t i = 0; i < words; i++) {
+      const size_t b_off = i << 2;
+      const uint32_t t_word = state[RATE_W ^ i] ^ buffer[i];
+
+      tag[b_off ^ 0] = static_cast<uint8_t>(t_word >> 0);
+      tag[b_off ^ 1] = static_cast<uint8_t>(t_word >> 8);
+      tag[b_off ^ 2] = static_cast<uint8_t>(t_word >> 16);
+      tag[b_off ^ 3] = static_cast<uint8_t>(t_word >> 24);
+    }
   }
 }
 


### PR DESCRIPTION
On little endian systems, do compile-time check so that `std::memcpy` can be used. 