### PR TITLE
Add usage example

### DIFF
--- a/example/aead.cpp
+++ b/example/aead.cpp
@@ -1,0 +1,161 @@
+#include <cassert>
+#include <iostream>
+
+#include "schwaemm128_128.hpp"
+#include "schwaemm192_192.hpp"
+#include "schwaemm256_128.hpp"
+#include "schwaemm256_256.hpp"
+
+int main() {
+  constexpr size_t d_len = 32ul;
+  constexpr size_t ct_len = 32ul;
+
+  uint8_t data[d_len];
+  uint8_t txt[ct_len];
+  uint8_t enc[ct_len];
+  uint8_t dec[ct_len];
+
+  random_data(data, d_len);
+  random_data(txt, d_len);
+
+  std::cout << "data = " << to_hex(data, sizeof(data)) << std::endl;
+  std::cout << "text = " << to_hex(txt, sizeof(txt)) << std::endl;
+
+  {
+    std::cout << "\nSchwaemm128-128 AEAD\n" << std::endl;
+
+    uint8_t key[schwaemm128_128::C];
+    uint8_t nonce[schwaemm128_128::R];
+    uint8_t tag[schwaemm128_128::C];
+
+    random_data(key, sizeof(key));
+    random_data(nonce, sizeof(nonce));
+
+    std::memset(enc, 0, sizeof(enc));
+    std::memset(dec, 0, sizeof(dec));
+
+    using namespace schwaemm128_128;
+
+    encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+    const bool f = decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
+
+    assert(f);
+
+    bool cmp = false;
+    for (size_t i = 0; i < ct_len; i++) {
+      cmp |= dec[i] ^ txt[i];
+    }
+
+    assert(!cmp);
+
+    std::cout << "key           = " << to_hex(key, sizeof(key)) << std::endl;
+    std::cout << "nonce         = " << to_hex(nonce, sizeof(nonce))
+              << std::endl;
+    std::cout << "cipher        = " << to_hex(enc, sizeof(enc)) << std::endl;
+    std::cout << "decrypted     = " << to_hex(dec, sizeof(dec)) << std::endl;
+  }
+
+  {
+    std::cout << "\nSchwaemm192-192 AEAD\n" << std::endl;
+
+    uint8_t key[schwaemm192_192::C];
+    uint8_t nonce[schwaemm192_192::R];
+    uint8_t tag[schwaemm192_192::C];
+
+    random_data(key, sizeof(key));
+    random_data(nonce, sizeof(nonce));
+
+    std::memset(enc, 0, sizeof(enc));
+    std::memset(dec, 0, sizeof(dec));
+
+    using namespace schwaemm192_192;
+
+    encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+    const bool f = decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
+
+    assert(f);
+
+    bool cmp = false;
+    for (size_t i = 0; i < ct_len; i++) {
+      cmp |= dec[i] ^ txt[i];
+    }
+
+    assert(!cmp);
+
+    std::cout << "key           = " << to_hex(key, sizeof(key)) << std::endl;
+    std::cout << "nonce         = " << to_hex(nonce, sizeof(nonce))
+              << std::endl;
+    std::cout << "cipher        = " << to_hex(enc, sizeof(enc)) << std::endl;
+    std::cout << "decrypted     = " << to_hex(dec, sizeof(dec)) << std::endl;
+  }
+
+  {
+    std::cout << "\nSchwaemm256-128 AEAD\n" << std::endl;
+
+    uint8_t key[schwaemm256_128::C];
+    uint8_t nonce[schwaemm256_128::R];
+    uint8_t tag[schwaemm256_128::C];
+
+    random_data(key, sizeof(key));
+    random_data(nonce, sizeof(nonce));
+
+    std::memset(enc, 0, sizeof(enc));
+    std::memset(dec, 0, sizeof(dec));
+
+    using namespace schwaemm256_128;
+
+    encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+    const bool f = decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
+
+    assert(f);
+
+    bool cmp = false;
+    for (size_t i = 0; i < ct_len; i++) {
+      cmp |= dec[i] ^ txt[i];
+    }
+
+    assert(!cmp);
+
+    std::cout << "key           = " << to_hex(key, sizeof(key)) << std::endl;
+    std::cout << "nonce         = " << to_hex(nonce, sizeof(nonce))
+              << std::endl;
+    std::cout << "cipher        = " << to_hex(enc, sizeof(enc)) << std::endl;
+    std::cout << "decrypted     = " << to_hex(dec, sizeof(dec)) << std::endl;
+  }
+
+  {
+    std::cout << "\nSchwaemm256-256 AEAD\n" << std::endl;
+
+    uint8_t key[schwaemm256_256::C];
+    uint8_t nonce[schwaemm256_256::R];
+    uint8_t tag[schwaemm256_256::C];
+
+    random_data(key, sizeof(key));
+    random_data(nonce, sizeof(nonce));
+
+    std::memset(enc, 0, sizeof(enc));
+    std::memset(dec, 0, sizeof(dec));
+
+    using namespace schwaemm256_256;
+
+    encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+    const bool f = decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
+
+    assert(f);
+
+    bool cmp = false;
+    for (size_t i = 0; i < ct_len; i++) {
+      cmp |= dec[i] ^ txt[i];
+    }
+
+    assert(!cmp);
+
+    std::cout << "key           = " << to_hex(key, sizeof(key)) << std::endl;
+    std::cout << "nonce         = " << to_hex(nonce, sizeof(nonce))
+              << std::endl;
+    std::cout << "cipher        = " << to_hex(enc, sizeof(enc)) << std::endl;
+    std::cout << "decrypted     = " << to_hex(dec, sizeof(dec)) << std::endl;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/example/hash.cpp
+++ b/example/hash.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+
+#include "esch256.hpp"
+#include "esch384.hpp"
+
+int main() {
+  constexpr size_t d_len = 32ul;
+  uint8_t data[d_len];
+
+  random_data(data, d_len);
+
+  uint8_t dig0[32];
+  uint8_t dig1[48];
+
+  esch256::hash(data, d_len, dig0);
+  esch384::hash(data, d_len, dig1);
+
+  std::cout << "esch256( " << to_hex(data, d_len)
+            << " ) = " << to_hex(dig0, sizeof(dig0)) << std::endl;
+
+  std::cout << "esch384( " << to_hex(data, d_len)
+            << " ) = " << to_hex(dig1, sizeof(dig1)) << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/include/bench_aead.hpp
+++ b/include/bench_aead.hpp
@@ -16,21 +16,21 @@ static void schwaemm256_128_encrypt(benchmark::State& state) {
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
   uint8_t* enc = static_cast<uint8_t*>(malloc(ct_len));
   uint8_t* data = static_cast<uint8_t*>(malloc(dt_len));
-  uint8_t* key = static_cast<uint8_t*>(malloc(16));
-  uint8_t* nonce = static_cast<uint8_t*>(malloc(32));
-  uint8_t* tag = static_cast<uint8_t*>(malloc(16));
+  uint8_t* key = static_cast<uint8_t*>(malloc(schwaemm256_128::C));
+  uint8_t* nonce = static_cast<uint8_t*>(malloc(schwaemm256_128::R));
+  uint8_t* tag = static_cast<uint8_t*>(malloc(schwaemm256_128::C));
 
   // random plain text bytes
   random_data(text, ct_len);
   // random associated data bytes
   random_data(data, dt_len);
   // random secret key ( = 128 -bit )
-  random_data(key, 16);
+  random_data(key, schwaemm256_128::C);
   // random public message nonce ( = 256 -bit )
-  random_data(nonce, 32);
+  random_data(nonce, schwaemm256_128::R);
 
   memset(enc, 0, ct_len);
-  memset(tag, 0, 16);
+  memset(tag, 0, schwaemm256_128::C);
 
   for (auto _ : state) {
     schwaemm256_128::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
@@ -63,22 +63,22 @@ static void schwaemm256_128_decrypt(benchmark::State& state) {
   uint8_t* enc = static_cast<uint8_t*>(malloc(ct_len));
   uint8_t* dec = static_cast<uint8_t*>(malloc(ct_len));
   uint8_t* data = static_cast<uint8_t*>(malloc(dt_len));
-  uint8_t* key = static_cast<uint8_t*>(malloc(16));
-  uint8_t* nonce = static_cast<uint8_t*>(malloc(32));
-  uint8_t* tag = static_cast<uint8_t*>(malloc(16));
+  uint8_t* key = static_cast<uint8_t*>(malloc(schwaemm256_128::C));
+  uint8_t* nonce = static_cast<uint8_t*>(malloc(schwaemm256_128::R));
+  uint8_t* tag = static_cast<uint8_t*>(malloc(schwaemm256_128::C));
 
   // random plain text bytes
   random_data(text, ct_len);
   // random associated data bytes
   random_data(data, dt_len);
   // random secret key ( = 128 -bit )
-  random_data(key, 16);
+  random_data(key, schwaemm256_128::C);
   // random public message nonce ( = 256 -bit )
-  random_data(nonce, 32);
+  random_data(nonce, schwaemm256_128::R);
 
   memset(enc, 0, ct_len);
   memset(dec, 0, ct_len);
-  memset(tag, 0, 16);
+  memset(tag, 0, schwaemm256_128::C);
 
   schwaemm256_128::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
 
@@ -109,7 +109,8 @@ static void schwaemm256_128_decrypt(benchmark::State& state) {
 static void schwaemm192_192_encrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
-  constexpr size_t KNT_LEN = 24;
+
+  constexpr size_t KNT_LEN = schwaemm192_192::R;
 
   // acquire memory resources
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
@@ -156,7 +157,8 @@ static void schwaemm192_192_encrypt(benchmark::State& state) {
 static void schwaemm192_192_decrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
-  constexpr size_t KNT_LEN = 24;
+
+  constexpr size_t KNT_LEN = schwaemm192_192::R;
 
   // acquire memory resources
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
@@ -209,7 +211,8 @@ static void schwaemm192_192_decrypt(benchmark::State& state) {
 static void schwaemm128_128_encrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
-  constexpr size_t KNT_LEN = 16;
+
+  constexpr size_t KNT_LEN = schwaemm128_128::R;
 
   // acquire memory resources
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
@@ -256,7 +259,8 @@ static void schwaemm128_128_encrypt(benchmark::State& state) {
 static void schwaemm128_128_decrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
-  constexpr size_t KNT_LEN = 16;
+
+  constexpr size_t KNT_LEN = schwaemm128_128::R;
 
   // acquire memory resources
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
@@ -310,7 +314,7 @@ static void schwaemm256_256_encrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
-  constexpr size_t KNT_LEN = schwaemm256_256::RATE;
+  constexpr size_t KNT_LEN = schwaemm256_256::R;
 
   // acquire memory resources
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
@@ -358,7 +362,7 @@ static void schwaemm256_256_decrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
-  constexpr size_t KNT_LEN = schwaemm256_256::RATE;
+  constexpr size_t KNT_LEN = schwaemm256_256::R;
 
   // acquire memory resources
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));


### PR DESCRIPTION
Added `sparkle` API usage example for both hashing & authenticated encryption.