### PR TITLE
Add Usage Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,3 +248,21 @@ schwaemm256_256_decrypt/2048/32      13063 ns        13053 ns        52986 bytes
 schwaemm256_256_encrypt/4096/32      25616 ns        25599 ns        27289 bytes_per_second=153.784M/s
 schwaemm256_256_decrypt/4096/32      25325 ns        25310 ns        27221 bytes_per_second=155.543M/s
 ```
+
+## Usage
+
+Using Sparkle C++ API is as easy as including proper header files & letting compiler know where it can find these header files, which is `./include` directory.
+
+If you're interested in
+
+- Esch256 Hash, import `./include/esch256.hpp`
+- Esch384 Hash, import `./include/esch384.hpp`
+- Schwaemm128-128 AEAD, import `./include/schwaemm128_128.hpp`
+- Schwaemm192-192 AEAD, import `./include/schwaemm192_192.hpp`
+- Schwaemm256-128 AEAD, import `./include/schwaemm256_128.hpp`
+- Schwaemm256-256 AEAD, import `./include/schwaemm256_256.hpp`
+
+I'm maintaining following examples for practically demonstrating usage of Sparkle C++ API.
+
+- For Esch{256, 384} Hash, see [here](https://github.com/itzmeanjan/sparkle/blob/96c33f8/example/hash.cpp)
+- For Schwaemm{128, 192, 256}-{128, 192, 256} AEAD, see [here](https://github.com/itzmeanjan/sparkle/blob/96c33f8/example/aead.cpp)

--- a/example/aead.cpp
+++ b/example/aead.cpp
@@ -6,17 +6,22 @@
 #include "schwaemm256_128.hpp"
 #include "schwaemm256_256.hpp"
 
-int main() {
-  constexpr size_t d_len = 32ul;
-  constexpr size_t ct_len = 32ul;
+// Compile it with
+//
+// g++ -std=c++20 -Wall -I ./include example/aead.cpp
+int
+main()
+{
+  constexpr size_t d_len = 32ul;  // associate data byte length
+  constexpr size_t ct_len = 32ul; // plain/ cipher text byte length
 
   uint8_t data[d_len];
   uint8_t txt[ct_len];
   uint8_t enc[ct_len];
   uint8_t dec[ct_len];
 
-  random_data(data, d_len);
-  random_data(txt, d_len);
+  random_data(data, d_len); // generate random associated data
+  random_data(txt, d_len);  // generate random plain text
 
   std::cout << "data = " << to_hex(data, sizeof(data)) << std::endl;
   std::cout << "text = " << to_hex(txt, sizeof(txt)) << std::endl;
@@ -36,7 +41,9 @@ int main() {
 
     using namespace schwaemm128_128;
 
+    // authenticated encryption with Schwaemm128-128 AEAD
     encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+    // verified decryption with Schwaemm128-128 AEAD
     const bool f = decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
 
     assert(f);
@@ -70,7 +77,9 @@ int main() {
 
     using namespace schwaemm192_192;
 
+    // authenticated encryption with Schwaemm192-192 AEAD
     encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+    // verified decryption with Schwaemm192-192 AEAD
     const bool f = decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
 
     assert(f);
@@ -104,7 +113,9 @@ int main() {
 
     using namespace schwaemm256_128;
 
+    // authenticated encryption with Schwaemm256-128 AEAD
     encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+    // verified decryption with Schwaemm256-128 AEAD
     const bool f = decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
 
     assert(f);
@@ -138,7 +149,9 @@ int main() {
 
     using namespace schwaemm256_256;
 
+    // authenticated encryption with Schwaemm256-256 AEAD
     encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+    // verified decryption with Schwaemm256-256 AEAD
     const bool f = decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
 
     assert(f);

--- a/example/hash.cpp
+++ b/example/hash.cpp
@@ -3,16 +3,27 @@
 #include "esch256.hpp"
 #include "esch384.hpp"
 
-int main() {
-  constexpr size_t d_len = 32ul;
+// Compile it with
+//
+// g++ -std=c++20 -Wall -I ./include example/hash.cpp
+int
+main()
+{
+  constexpr size_t d_len = 32ul; // message length in bytes
+
   uint8_t data[d_len];
-
-  random_data(data, d_len);
-
   uint8_t dig0[32];
   uint8_t dig1[48];
 
+  // random message bytes
+  random_data(data, d_len);
+
+  std::memset(dig0, 0, sizeof(dig0));
+  std::memset(dig1, 0, sizeof(dig1));
+
+  // compute Esch256 digest
   esch256::hash(data, d_len, dig0);
+  // compute Esch384 digest
   esch384::hash(data, d_len, dig1);
 
   std::cout << "esch256( " << to_hex(data, d_len)


### PR DESCRIPTION
This PR adds `sparkle` C++ API usage examples, while linking those on README. 