### PR TITLE
Refactor Sparkle Cipher Suite

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,250 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: NextLine
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequiresClause: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RequiresClausePosition: OwnLine
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 ---
 Language:        Cpp
-# BasedOnStyle:  Google
-AccessModifierOffset: -1
+# BasedOnStyle:  Mozilla
+AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
 AlignConsecutiveAssignments:
@@ -28,98 +28,94 @@ AlignConsecutiveMacros:
   AcrossComments:  false
   AlignCompound:   false
   PadOperators:    false
-AlignEscapedNewlines: Left
+AlignEscapedNewlines: Right
 AlignOperands:   Align
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: Inline
 AllowShortLambdasOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: WithoutElse
-AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: TopLevel
+AlwaysBreakAfterReturnType: TopLevel
+AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: Yes
 AttributeMacros:
   - __capability
-BinPackArguments: true
-BinPackParameters: true
+BinPackArguments: false
+BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel:  false
-  AfterClass:      false
+  AfterClass:      true
   AfterControlStatement: Never
-  AfterEnum:       false
-  AfterFunction:   false
+  AfterEnum:       true
+  AfterFunction:   true
   AfterNamespace:  false
   AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
   BeforeCatch:     false
   BeforeElse:      false
   BeforeLambdaBody: false
   BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: true
-  SplitEmptyRecord: true
+  SplitEmptyRecord: false
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
 BreakBeforeConceptDeclarations: Always
-BreakBeforeBraces: Attach
+BreakBeforeBraces: Mozilla
 BreakBeforeInheritanceComma: false
-BreakInheritanceList: BeforeColon
+BreakInheritanceList: BeforeComma
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
 QualifierAlignment: Leave
 CompactNamespaces: false
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
 DeriveLineEnding: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
-PackConstructorInitializers: NextLine
+PackConstructorInitializers: BinPack
 BasedOnStyle:    ''
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 AllowAllConstructorInitializersOnNextLine: true
-FixNamespaceComments: true
+FixNamespaceComments: false
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
 IfMacros:
   - KJ_IF_MAYBE
-IncludeBlocks:   Regroup
+IncludeBlocks:   Preserve
 IncludeCategories:
-  - Regex:           '^<ext/.*\.h>'
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
     SortPriority:    0
     CaseSensitive:   false
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '^<.*'
-    Priority:        2
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '.*'
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
     Priority:        3
     SortPriority:    0
     CaseSensitive:   false
-IncludeIsMainRegex: '([-_](test|unittest))?$'
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
 IndentCaseLabels: true
@@ -134,19 +130,19 @@ InsertBraces:    false
 InsertTrailingCommas: None
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtTheStartOfBlocks: true
 LambdaBodyIndentation: Signature
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-ObjCBinPackProtocolList: Never
+ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
 PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakOpenParenthesis: 0
@@ -157,36 +153,6 @@ PenaltyReturnTypeOnItsOwnLine: 200
 PenaltyIndentedWhitespace: 0
 PointerAlignment: Left
 PPIndentWidth:   -1
-RawStringFormats:
-  - Language:        Cpp
-    Delimiters:
-      - cc
-      - CC
-      - cpp
-      - Cpp
-      - CPP
-      - 'c++'
-      - 'C++'
-    CanonicalDelimiter: ''
-    BasedOnStyle:    google
-  - Language:        TextProto
-    Delimiters:
-      - pb
-      - PB
-      - proto
-      - PROTO
-    EnclosingFunctions:
-      - EqualsProto
-      - EquivToProto
-      - PARSE_PARTIAL_TEXT_PROTO
-      - PARSE_TEST_PROTO
-      - PARSE_TEXT_PROTO
-      - ParseTextOrDie
-      - ParseTextProtoOrDie
-      - ParseTestProto
-      - ParsePartialTestProto
-    CanonicalDelimiter: pb
-    BasedOnStyle:    google
 ReferenceAlignment: Pointer
 ReflowComments:  true
 RemoveBracesLLVM: false
@@ -198,7 +164,7 @@ SortJavaStaticImport: Before
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
-SpaceAfterTemplateKeyword: true
+SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
@@ -219,7 +185,7 @@ SpaceAroundPointerQualifiers: Default
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 2
+SpacesBeforeTrailingComments: 1
 SpacesInAngles:  Never
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
@@ -231,7 +197,7 @@ SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
 BitFieldColonSpacing: Both
-Standard:        Auto
+Standard:        Latest
 StatementAttributeLikeMacros:
   - Q_EMIT
 StatementMacros:

--- a/.github/workflows/test_kat.yml
+++ b/.github/workflows/test_kat.yml
@@ -1,4 +1,4 @@
-name: Test against Known Answer Tests on Github
+name: Test Sparkle Cipher Suite using Known Answer Tests
 
 on:
   push:
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup compiler
-      run: sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10; sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
+      run: |
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
     - name: Install Python dependencies
       run: python3 -m pip install -r wrapper/python/requirements.txt --user
     - name: Execute tests
-      run: make test_kat
-    - name: Clean it up
-      run: make clean
+      run: make

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 *.a
 *.o
 __pycache__
+
+# For Clangd
+compile_commands.json
+.cache

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX = g++
 CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
-OPTFLAGS = -O3
+OPTFLAGS = -O3 -march=native -mtune=native
 IFLAGS = -I ./include
 
 all: test_kat

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 	find . -name '*.out' -o -name '*.o' -o -name '*.so' -o -name '*.gch' | xargs rm -rf
 
 format:
-	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Google
+	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i
 
 test_kat:
 	bash test_kat.sh

--- a/README.md
+++ b/README.md
@@ -5,21 +5,22 @@ Accelerated Sparkle - Lightweight Authenticated Encryption &amp; Hashing
 
 After implementing `ascon`, `tinyjambu` & `xoodyak`, I've picked up `sparkle` --- another NIST Light Weight Cryptography ( LWC ) final round candidate, which offers following functions
 
-- Esch{256, 384}: Lightweight, cryptographic secure Hash function, producing 256/ 384 -bit output digest, when provided with N -bytes input | N >= 0
-- Schwaemm256-{128, 256}/ Schwaemm128-128/ Schwaemm192-192: Authenticated encryption with associated data ( AEAD ) scheme, which takes 128/ 192/ 256 -bit secret key, 128/ 192/ 256 -bit public message nonce, N -bytes associated data, M -bytes plain text | N, M >= 0 and computes M -bytes encrypted data along with 128/ 192/ 256 -bit authentication tag. During verified decryption step, one needs to provide secret key, public message nonce, authentication tag, associated data & encrypted bytes to decrypt routine, which produces equal many decrypted data bytes & boolean verification flag. Before consuming decrypted bytes, one **must** check presence of truth value in boolean verification flag. Note, that associated data is never encrypted.
+Functionality | What does it offer ?
+:-- | --:
+Esch{256, 384} | Lightweight, cryptographic secure Hash function, producing 256/ 384 -bit output digest, when provided with N -bytes input s.t. N >= 0
+Schwaemm256-{128, 256}/ Schwaemm128-128/ Schwaemm192-192 | Authenticated encryption with associated data ( AEAD ) scheme, which takes 128/ 192/ 256 -bit secret key, 128/ 192/ 256 -bit public message nonce, N -bytes associated data, M -bytes plain text s.t. N, M >= 0 and computes M -bytes encrypted data along with 128/ 192/ 256 -bit authentication tag. During verified decryption step, one needs to provide secret key, public message nonce, authentication tag, associated data & encrypted bytes to decrypt routine, which produces equal many decrypted data bytes & boolean verification flag. **If tag verification fails during decryption, no unverified plain text is released**.
 
-> Sparkle AEAD schemes provide confidentiality only for plain text, though it provides integrity & authenticity for both plain text & associated data. Read Sparkle [specification](https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf) for better understanding.
+> **Warning** Sparkle AEAD schemes provide confidentiality only for plain text, though it provides integrity & authenticity for both plain text & associated data. Read Sparkle [specification](https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf) for better understanding.
 
-In this repository, I'm keeping one zero-dependency, header-only, easy-to-use C++ library, implementing Sparkle Hash & AEAD specification, while using C++20 features ( note for compilation step ). Using it's as easy as including header files in your C++ project. I've also kept C-ABI compliant wrapper functions, which can be interfaced from other languages such as Python, Rust ( using FFI; [more](https://en.wikipedia.org/wiki/Foreign_function_interface) ).
+In this repository, I'm maintaining one zero-dependency, header-only, easy-to-use C++ library, implementing Sparkle Hash & AEAD specification, while using C++20 features ( note this when you're compiling your project ). Using it is as easy as including proper header files ( generally [esch.hpp](./include/esch.hpp) or [schwaemm.hpp](./include/schwaemm.hpp) ) in your C++ project and letting compiler know where it can find these headers. I've also kept C-ABI compliant wrapper functions, which can be interfaced from other languages such as Python, Rust ( using FFI; [more](https://en.wikipedia.org/wiki/Foreign_function_interface) ).
 
-> Learn more about AEAD [here](https://en.wikipedia.org/wiki/Authenticated_encryption)
+> **Note** Learn more about AEAD [here](https://en.wikipedia.org/wiki/Authenticated_encryption)
 
-> If interested in my work on Ascon, [see](https://github.com/itzmeanjan/ascon)
+> **Note** If interested in my work on other NIST LWC finalists such as
 
-> If interested in my work on TinyJambu, [see](https://github.com/itzmeanjan/tinyjambu)
-
-
-> If interested in my work on Xoodyak, [see](https://github.com/itzmeanjan/xoodyak)
+- Ascon, [see](https://github.com/itzmeanjan/ascon)
+- TinyJambu, [see](https://github.com/itzmeanjan/tinyjambu)
+- Xoodyak, [see](https://github.com/itzmeanjan/xoodyak)
 
 While writing this implementation of Sparkle, I followed [this](https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf) specification, which was submitted to NIST LWC, see [here](https://csrc.nist.gov/projects/lightweight-cryptography/finalists).
 
@@ -27,38 +28,51 @@ While writing this implementation of Sparkle, I followed [this](https://csrc.nis
 
 - C++ compiler like `g++`/ `clang++`, with C++20 standard library support
 
-> I'm using
-
 ```bash
 $ g++ --version
-g++ (Ubuntu 11.2.0-19ubuntu1) 11.2.0
+g++ (Homebrew GCC 12.2.0) 12.2.0
+
+$ clang++ --version
+Apple clang version 14.0.0 (clang-1400.0.29.202)
 ```
 
-- System development utilities such as `make`/ `cmake`
-
-> I'm using
+- System development utilities such as `make`, `cmake`, `git`, `unzip`, `wget` and `python3`
 
 ```bash
 $ make --version
-GNU Make 4.3
+GNU Make 3.81
 
 $ cmake --version
-cmake version 3.22.1
-```
+cmake version 3.25.1
 
-- For testing functional correctness of Sparkle Hash & AEAD schemes, you'll need to have `wget`, `unzip`, `python3`.
+$ git --version
+git version 2.39.1
+
+$ unzip -v
+UnZip 6.00 of 20 April 2009, by Info-ZIP
+
+$ wget --version
+GNU Wget 1.21.3 built on darwin22.1.0
+
+$ python3 --version
+Python 3.10.9
+```
 
 - For installing `python3` dependencies, issue
 
 ```bash
+# ensure you've pip
 python3 -m pip install -r wrapper/python/requirements.txt --user
+
+# On Ubuntu you may, if pip is not available
+sudo apt-get install python3-pip
 ```
 
-- For benchmarking Sparkle Hash & AEAD implementations on CPU, you'll need `google-benchmark` library globally installed; see [here](https://github.com/google/benchmark/tree/60b16f1#installation)
+- For benchmarking Sparkle Hash & AEAD implementations on CPU, you'll need `google-benchmark` library globally installed; follow [this](https://github.com/google/benchmark/tree/60b16f1#installation) document.
 
 ## Testing
 
-For ensuring functional correctness & compatibility with Sparkle specification, I excute Sparkle Hash & AEAD functions on Known Answer Tests ( KATs ) provided with NIST LWC submission package of Sparkle & check computed results against provided ones.
+For ensuring functional correctness & compatibility with Sparkle specification, I excute Sparkle Hash & AEAD functions on test vectors ( KATs ) provided with NIST LWC submission package of Sparkle & check computed results against provided ones.
 
 Issue following command to test
 
@@ -74,98 +88,12 @@ For benchmarking Sparkle Hash & AEAD functions on CPU, I'm using `google-benchma
 make benchmark
 ```
 
-> If you've CPU scaling enabled, you may want to disable that; see [this](https://github.com/google/benchmark/blob/60b16f11a30146ac825b7d99be0b9887c24b254a/docs/user_guide.md#disabling-cpu-frequency-scaling) guide
+> **Warning** If you've CPU scaling enabled, you may want to disable that; see [this](https://github.com/google/benchmark/blob/60b16f11a30146ac825b7d99be0b9887c24b254a/docs/user_guide.md#disabling-cpu-frequency-scaling) guide
 
-### On ARM Cortex-A72
-
-```bash
-2022-05-30T08:10:37+00:00
-Running ./bench/a.out
-Run on (16 X 166.66 MHz CPU s)
-CPU Caches:
-  L1 Data 32 KiB (x16)
-  L1 Instruction 48 KiB (x16)
-  L2 Unified 2048 KiB (x4)
-Load Average: 0.26, 0.06, 0.02
-------------------------------------------------------------------------------------------
-Benchmark                                Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------
-esch256_hash/64                        879 ns          879 ns       795737 bytes_per_second=69.4144M/s
-esch256_hash/128                      1488 ns         1488 ns       470564 bytes_per_second=82.0623M/s
-esch256_hash/256                      2688 ns         2688 ns       260385 bytes_per_second=90.8156M/s
-esch256_hash/512                      5090 ns         5090 ns       137520 bytes_per_second=95.9291M/s
-esch256_hash/1024                     9893 ns         9893 ns        70752 bytes_per_second=98.7122M/s
-esch256_hash/2048                    19500 ns        19500 ns        35897 bytes_per_second=100.163M/s
-esch256_hash/4096                    38713 ns        38713 ns        18082 bytes_per_second=100.904M/s
-esch384_hash/64                       2587 ns         2587 ns       271018 bytes_per_second=23.5962M/s
-esch384_hash/128                      4132 ns         4132 ns       169352 bytes_per_second=29.5404M/s
-esch384_hash/256                      7241 ns         7241 ns        96679 bytes_per_second=33.7153M/s
-esch384_hash/512                     13460 ns        13460 ns        52010 bytes_per_second=36.2773M/s
-esch384_hash/1024                    25898 ns        25897 ns        27030 bytes_per_second=37.7094M/s
-esch384_hash/2048                    50763 ns        50763 ns        13788 bytes_per_second=38.4754M/s
-esch384_hash/4096                   100503 ns       100499 ns         6965 bytes_per_second=38.8686M/s
-schwaemm256_128_encrypt/64/32         1120 ns         1120 ns       625034 bytes_per_second=81.7501M/s
-schwaemm256_128_decrypt/64/32         1147 ns         1147 ns       610513 bytes_per_second=79.8481M/s
-schwaemm256_128_encrypt/128/32        1519 ns         1519 ns       460700 bytes_per_second=100.43M/s
-schwaemm256_128_decrypt/128/32        1545 ns         1545 ns       453014 bytes_per_second=98.7519M/s
-schwaemm256_128_encrypt/256/32        2327 ns         2327 ns       299629 bytes_per_second=118.041M/s
-schwaemm256_128_decrypt/256/32        2350 ns         2350 ns       297862 bytes_per_second=116.872M/s
-schwaemm256_128_encrypt/512/32        3923 ns         3923 ns       178431 bytes_per_second=132.238M/s
-schwaemm256_128_decrypt/512/32        3944 ns         3944 ns       177469 bytes_per_second=131.529M/s
-schwaemm256_128_encrypt/1024/32       7118 ns         7118 ns        98328 bytes_per_second=141.477M/s
-schwaemm256_128_decrypt/1024/32       7133 ns         7133 ns        98132 bytes_per_second=141.19M/s
-schwaemm256_128_encrypt/2048/32      13510 ns        13509 ns        51816 bytes_per_second=146.835M/s
-schwaemm256_128_decrypt/2048/32      13511 ns        13510 ns        51812 bytes_per_second=146.826M/s
-schwaemm256_128_encrypt/4096/32      26292 ns        26291 ns        26625 bytes_per_second=149.737M/s
-schwaemm256_128_decrypt/4096/32      26276 ns        26275 ns        26641 bytes_per_second=149.827M/s
-schwaemm192_192_encrypt/64/32         1495 ns         1495 ns       468214 bytes_per_second=61.24M/s
-schwaemm192_192_decrypt/64/32         1554 ns         1554 ns       450350 bytes_per_second=58.9061M/s
-schwaemm192_192_encrypt/128/32        2071 ns         2071 ns       335520 bytes_per_second=73.6829M/s
-schwaemm192_192_decrypt/128/32        2121 ns         2121 ns       327122 bytes_per_second=71.9501M/s
-schwaemm192_192_encrypt/256/32        3014 ns         3014 ns       232225 bytes_per_second=91.1157M/s
-schwaemm192_192_decrypt/256/32        3074 ns         3074 ns       227747 bytes_per_second=89.3623M/s
-schwaemm192_192_encrypt/512/32        5090 ns         5090 ns       137502 bytes_per_second=101.922M/s
-schwaemm192_192_decrypt/512/32        5150 ns         5149 ns       135903 bytes_per_second=100.749M/s
-schwaemm192_192_encrypt/1024/32       9057 ns         9057 ns        77285 bytes_per_second=111.194M/s
-schwaemm192_192_decrypt/1024/32       9116 ns         9116 ns        76786 bytes_per_second=110.472M/s
-schwaemm192_192_encrypt/2048/32      17176 ns        17176 ns        40754 bytes_per_second=115.49M/s
-schwaemm192_192_decrypt/2048/32      17235 ns        17235 ns        40614 bytes_per_second=115.093M/s
-schwaemm192_192_encrypt/4096/32      33229 ns        33229 ns        21066 bytes_per_second=118.475M/s
-schwaemm192_192_decrypt/4096/32      33298 ns        33298 ns        21018 bytes_per_second=118.228M/s
-schwaemm128_128_encrypt/64/32         1127 ns         1127 ns       620875 bytes_per_second=81.2045M/s
-schwaemm128_128_decrypt/64/32         1134 ns         1134 ns       617326 bytes_per_second=80.7393M/s
-schwaemm128_128_encrypt/128/32        1678 ns         1678 ns       417056 bytes_per_second=90.9174M/s
-schwaemm128_128_decrypt/128/32        1667 ns         1667 ns       419818 bytes_per_second=91.5156M/s
-schwaemm128_128_encrypt/256/32        2765 ns         2764 ns       253231 bytes_per_second=99.3551M/s
-schwaemm128_128_decrypt/256/32        2719 ns         2719 ns       257486 bytes_per_second=101.026M/s
-schwaemm128_128_encrypt/512/32        4936 ns         4936 ns       141816 bytes_per_second=105.105M/s
-schwaemm128_128_decrypt/512/32        4821 ns         4821 ns       145197 bytes_per_second=107.61M/s
-schwaemm128_128_encrypt/1024/32       9281 ns         9281 ns        75422 bytes_per_second=108.513M/s
-schwaemm128_128_decrypt/1024/32       9026 ns         9026 ns        77542 bytes_per_second=111.575M/s
-schwaemm128_128_encrypt/2048/32      17969 ns        17969 ns        38955 bytes_per_second=110.393M/s
-schwaemm128_128_decrypt/2048/32      17436 ns        17436 ns        40146 bytes_per_second=113.766M/s
-schwaemm128_128_encrypt/4096/32      35347 ns        35346 ns        19804 bytes_per_second=111.377M/s
-schwaemm128_128_decrypt/4096/32      34268 ns        34268 ns        20427 bytes_per_second=114.882M/s
-schwaemm256_256_encrypt/64/32         2295 ns         2295 ns       305004 bytes_per_second=39.8946M/s
-schwaemm256_256_decrypt/64/32         2371 ns         2371 ns       295050 bytes_per_second=38.6162M/s
-schwaemm256_256_encrypt/128/32        3115 ns         3115 ns       225002 bytes_per_second=48.9783M/s
-schwaemm256_256_decrypt/128/32        3221 ns         3221 ns       217152 bytes_per_second=47.3688M/s
-schwaemm256_256_encrypt/256/32        4734 ns         4734 ns       147934 bytes_per_second=58.0167M/s
-schwaemm256_256_decrypt/256/32        4915 ns         4915 ns       142568 bytes_per_second=55.8786M/s
-schwaemm256_256_encrypt/512/32        7979 ns         7979 ns        87756 bytes_per_second=65.0199M/s
-schwaemm256_256_decrypt/512/32        8295 ns         8295 ns        84383 bytes_per_second=62.5439M/s
-schwaemm256_256_encrypt/1024/32      14455 ns        14455 ns        48433 bytes_per_second=69.6691M/s
-schwaemm256_256_decrypt/1024/32      15049 ns        15049 ns        46514 bytes_per_second=66.9196M/s
-schwaemm256_256_encrypt/2048/32      27429 ns        27429 ns        25526 bytes_per_second=72.3199M/s
-schwaemm256_256_decrypt/2048/32      28570 ns        28569 ns        24503 bytes_per_second=69.4329M/s
-schwaemm256_256_encrypt/4096/32      53352 ns        53352 ns        13120 bytes_per_second=73.7892M/s
-schwaemm256_256_decrypt/4096/32      55628 ns        55627 ns        12583 bytes_per_second=70.7712M/s
-```
-
-### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
+### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz ( compiled using Clang )
 
 ```bash
-2022-05-30T11:47:55+04:00
+2023-01-20T12:29:38+04:00
 Running ./bench/a.out
 Run on (8 X 2400 MHz CPU s)
 CPU Caches:
@@ -173,80 +101,86 @@ CPU Caches:
   L1 Instruction 32 KiB
   L2 Unified 256 KiB (x4)
   L3 Unified 6144 KiB
-Load Average: 1.86, 2.21, 2.21
+Load Average: 1.33, 1.42, 1.53
 ------------------------------------------------------------------------------------------
 Benchmark                                Time             CPU   Iterations UserCounters...
 ------------------------------------------------------------------------------------------
-esch256_hash/64                        976 ns          973 ns       673453 bytes_per_second=62.7573M/s
-esch256_hash/128                      1916 ns         1709 ns       433864 bytes_per_second=71.4076M/s
-esch256_hash/256                      3003 ns         2990 ns       235881 bytes_per_second=81.6467M/s
-esch256_hash/512                      6269 ns         5945 ns       121099 bytes_per_second=82.1263M/s
-esch256_hash/1024                    11746 ns        11649 ns        58407 bytes_per_second=83.8289M/s
-esch256_hash/2048                    23122 ns        22919 ns        30301 bytes_per_second=85.2189M/s
-esch256_hash/4096                    48235 ns        47647 ns        15792 bytes_per_second=81.9836M/s
-esch384_hash/64                       1282 ns         1278 ns       535537 bytes_per_second=47.7524M/s
-esch384_hash/128                      2228 ns         2205 ns       317092 bytes_per_second=55.3636M/s
-esch384_hash/256                      3915 ns         3873 ns       188784 bytes_per_second=63.039M/s
-esch384_hash/512                      7104 ns         7035 ns       103762 bytes_per_second=69.411M/s
-esch384_hash/1024                    13174 ns        13121 ns        50675 bytes_per_second=74.4262M/s
-esch384_hash/2048                    27419 ns        27090 ns        26228 bytes_per_second=72.0967M/s
-esch384_hash/4096                    52529 ns        52223 ns        12809 bytes_per_second=74.7998M/s
-schwaemm256_128_encrypt/64/32         1026 ns         1016 ns       703843 bytes_per_second=90.0907M/s
-schwaemm256_128_decrypt/64/32         1010 ns         1004 ns       660764 bytes_per_second=91.1863M/s
-schwaemm256_128_encrypt/128/32        1468 ns         1413 ns       491853 bytes_per_second=107.973M/s
-schwaemm256_128_decrypt/128/32        1395 ns         1381 ns       517556 bytes_per_second=110.506M/s
-schwaemm256_128_encrypt/256/32        2143 ns         2121 ns       306018 bytes_per_second=129.499M/s
-schwaemm256_128_decrypt/256/32        2034 ns         2026 ns       327564 bytes_per_second=135.551M/s
-schwaemm256_128_encrypt/512/32        3488 ns         3472 ns       205165 bytes_per_second=149.429M/s
-schwaemm256_128_decrypt/512/32        3577 ns         3535 ns       193651 bytes_per_second=146.765M/s
-schwaemm256_128_encrypt/1024/32       6207 ns         6188 ns       111231 bytes_per_second=162.734M/s
-schwaemm256_128_decrypt/1024/32       6374 ns         6306 ns       107176 bytes_per_second=159.692M/s
-schwaemm256_128_encrypt/2048/32      12223 ns        12115 ns        57263 bytes_per_second=163.731M/s
-schwaemm256_128_decrypt/2048/32      11490 ns        11451 ns        59898 bytes_per_second=173.232M/s
-schwaemm256_128_encrypt/4096/32      23329 ns        23227 ns        28865 bytes_per_second=169.489M/s
-schwaemm256_128_decrypt/4096/32      22630 ns        22582 ns        30772 bytes_per_second=174.329M/s
-schwaemm192_192_encrypt/64/32         1355 ns         1352 ns       509269 bytes_per_second=67.7147M/s
-schwaemm192_192_decrypt/64/32         1352 ns         1348 ns       515111 bytes_per_second=67.8931M/s
-schwaemm192_192_encrypt/128/32        2046 ns         2021 ns       369082 bytes_per_second=75.515M/s
-schwaemm192_192_decrypt/128/32        2063 ns         2028 ns       360758 bytes_per_second=75.2323M/s
-schwaemm192_192_encrypt/256/32        2769 ns         2762 ns       250239 bytes_per_second=99.4353M/s
-schwaemm192_192_decrypt/256/32        2714 ns         2710 ns       257102 bytes_per_second=101.342M/s
-schwaemm192_192_encrypt/512/32        5248 ns         5193 ns       100000 bytes_per_second=99.8998M/s
-schwaemm192_192_decrypt/512/32        5004 ns         4948 ns       111025 bytes_per_second=104.855M/s
-schwaemm192_192_encrypt/1024/32       8340 ns         8335 ns        79186 bytes_per_second=120.826M/s
-schwaemm192_192_decrypt/1024/32       8240 ns         8225 ns        83401 bytes_per_second=122.437M/s
-schwaemm192_192_encrypt/2048/32      16242 ns        16212 ns        42986 bytes_per_second=122.354M/s
-schwaemm192_192_decrypt/2048/32      15870 ns        15839 ns        43615 bytes_per_second=125.235M/s
-schwaemm192_192_encrypt/4096/32      33149 ns        31301 ns        22707 bytes_per_second=125.772M/s
-schwaemm192_192_decrypt/4096/32      30205 ns        30124 ns        23063 bytes_per_second=130.684M/s
-schwaemm128_128_encrypt/64/32          697 ns          696 ns       944071 bytes_per_second=131.483M/s
-schwaemm128_128_decrypt/64/32          695 ns          694 ns       990744 bytes_per_second=132.006M/s
-schwaemm128_128_encrypt/128/32         985 ns          984 ns       689546 bytes_per_second=155.124M/s
-schwaemm128_128_decrypt/128/32         974 ns          972 ns       708144 bytes_per_second=156.967M/s
-schwaemm128_128_encrypt/256/32        1558 ns         1557 ns       445712 bytes_per_second=176.388M/s
-schwaemm128_128_decrypt/256/32        1610 ns         1599 ns       399054 bytes_per_second=171.774M/s
-schwaemm128_128_encrypt/512/32        2714 ns         2710 ns       254258 bytes_per_second=191.445M/s
-schwaemm128_128_decrypt/512/32        2674 ns         2673 ns       260062 bytes_per_second=194.12M/s
-schwaemm128_128_encrypt/1024/32       5005 ns         4998 ns       134613 bytes_per_second=201.479M/s
-schwaemm128_128_decrypt/1024/32       4941 ns         4938 ns       135885 bytes_per_second=203.958M/s
-schwaemm128_128_encrypt/2048/32       9647 ns         9622 ns        71580 bytes_per_second=206.158M/s
-schwaemm128_128_decrypt/2048/32       9511 ns         9498 ns        72574 bytes_per_second=208.85M/s
-schwaemm128_128_encrypt/4096/32      18675 ns        18661 ns        36524 bytes_per_second=210.958M/s
-schwaemm128_128_decrypt/4096/32      18713 ns        18685 ns        36764 bytes_per_second=210.688M/s
-schwaemm256_256_encrypt/64/32         1077 ns         1076 ns       646138 bytes_per_second=85.1143M/s
-schwaemm256_256_decrypt/64/32         1084 ns         1083 ns       628530 bytes_per_second=84.5404M/s
-schwaemm256_256_encrypt/128/32        1469 ns         1466 ns       472973 bytes_per_second=104.049M/s
-schwaemm256_256_decrypt/128/32        1478 ns         1476 ns       466107 bytes_per_second=103.355M/s
-schwaemm256_256_encrypt/256/32        2260 ns         2258 ns       310427 bytes_per_second=121.611M/s
-schwaemm256_256_decrypt/256/32        2253 ns         2250 ns       307887 bytes_per_second=122.047M/s
-schwaemm256_256_encrypt/512/32        3815 ns         3811 ns       183769 bytes_per_second=136.136M/s
-schwaemm256_256_decrypt/512/32        3814 ns         3811 ns       184620 bytes_per_second=136.145M/s
-schwaemm256_256_encrypt/1024/32       6911 ns         6906 ns        95233 bytes_per_second=145.832M/s
-schwaemm256_256_decrypt/1024/32       6877 ns         6873 ns        98464 bytes_per_second=146.529M/s
-schwaemm256_256_encrypt/2048/32      13371 ns        13358 ns        52871 bytes_per_second=148.494M/s
-schwaemm256_256_decrypt/2048/32      13063 ns        13053 ns        52986 bytes_per_second=151.972M/s
-schwaemm256_256_encrypt/4096/32      25616 ns        25599 ns        27289 bytes_per_second=153.784M/s
-schwaemm256_256_decrypt/4096/32      25325 ns        25310 ns        27221 bytes_per_second=155.543M/s
+bench_sparkle::sparkle<4, 7>          56.8 ns         56.8 ns     12045083 bytes_per_second=537.669M/s
+bench_sparkle::sparkle<4, 10>         80.4 ns         80.4 ns      8572653 bytes_per_second=379.803M/s
+bench_sparkle::sparkle<6, 7>           120 ns          120 ns      5667236 bytes_per_second=381.158M/s
+bench_sparkle::sparkle<6, 11>          188 ns          188 ns      3683590 bytes_per_second=243.318M/s
+bench_sparkle::sparkle<8, 8>           181 ns          181 ns      3833642 bytes_per_second=336.992M/s
+bench_sparkle::sparkle<8, 12>          274 ns          274 ns      2555575 bytes_per_second=223.071M/s
+esch256_hash/64                        693 ns          692 ns       979007 bytes_per_second=88.1581M/s
+esch256_hash/128                      1183 ns         1182 ns       584434 bytes_per_second=103.314M/s
+esch256_hash/256                      2207 ns         2205 ns       313259 bytes_per_second=110.719M/s
+esch256_hash/512                      4208 ns         4190 ns       167479 bytes_per_second=116.529M/s
+esch256_hash/1024                     8106 ns         8098 ns        82031 bytes_per_second=120.6M/s
+esch256_hash/2048                    16029 ns        16006 ns        43802 bytes_per_second=122.024M/s
+esch256_hash/4096                    31538 ns        31506 ns        22182 bytes_per_second=123.986M/s
+esch384_hash/64                       1195 ns         1194 ns       565360 bytes_per_second=51.119M/s
+esch384_hash/128                      1951 ns         1948 ns       360229 bytes_per_second=62.6669M/s
+esch384_hash/256                      3443 ns         3440 ns       205665 bytes_per_second=70.9704M/s
+esch384_hash/512                      6339 ns         6332 ns       108202 bytes_per_second=77.1115M/s
+esch384_hash/1024                    12206 ns        12192 ns        56750 bytes_per_second=80.0994M/s
+esch384_hash/2048                    23965 ns        23929 ns        28942 bytes_per_second=81.6202M/s
+esch384_hash/4096                    47392 ns        47339 ns        14746 bytes_per_second=82.5159M/s
+schwaemm256_128_encrypt/64/32          739 ns          736 ns       944058 bytes_per_second=124.41M/s
+schwaemm256_128_decrypt/64/32          745 ns          744 ns       924996 bytes_per_second=123.063M/s
+schwaemm256_128_encrypt/128/32        1012 ns         1011 ns       699196 bytes_per_second=150.913M/s
+schwaemm256_128_decrypt/128/32        1077 ns         1077 ns       636856 bytes_per_second=141.721M/s
+schwaemm256_128_encrypt/256/32        1492 ns         1491 ns       464878 bytes_per_second=184.197M/s
+schwaemm256_128_decrypt/256/32        1517 ns         1516 ns       457681 bytes_per_second=181.167M/s
+schwaemm256_128_encrypt/512/32        2535 ns         2533 ns       275825 bytes_per_second=204.788M/s
+schwaemm256_128_decrypt/512/32        2535 ns         2532 ns       272598 bytes_per_second=204.86M/s
+schwaemm256_128_encrypt/1024/32       4532 ns         4528 ns       154314 bytes_per_second=222.4M/s
+schwaemm256_128_decrypt/1024/32       4601 ns         4596 ns       151337 bytes_per_second=219.126M/s
+schwaemm256_128_encrypt/2048/32       8555 ns         8550 ns        79427 bytes_per_second=232.006M/s
+schwaemm256_128_decrypt/2048/32       8734 ns         8726 ns        78770 bytes_per_second=227.338M/s
+schwaemm256_128_encrypt/4096/32      16657 ns        16644 ns        41507 bytes_per_second=236.527M/s
+schwaemm256_128_decrypt/4096/32      16910 ns        16898 ns        40713 bytes_per_second=232.967M/s
+schwaemm192_192_encrypt/64/32          988 ns          988 ns       703397 bytes_per_second=92.7009M/s
+schwaemm192_192_decrypt/64/32          994 ns          993 ns       696254 bytes_per_second=92.1954M/s
+schwaemm192_192_encrypt/128/32        1378 ns         1377 ns       502556 bytes_per_second=110.802M/s
+schwaemm192_192_decrypt/128/32        1389 ns         1388 ns       491680 bytes_per_second=109.905M/s
+schwaemm192_192_encrypt/256/32        2021 ns         2019 ns       340792 bytes_per_second=136.015M/s
+schwaemm192_192_decrypt/256/32        2031 ns         2029 ns       341537 bytes_per_second=135.365M/s
+schwaemm192_192_encrypt/512/32        3461 ns         3458 ns       198437 bytes_per_second=150.026M/s
+schwaemm192_192_decrypt/512/32        3452 ns         3448 ns       203055 bytes_per_second=150.464M/s
+schwaemm192_192_encrypt/1024/32       6170 ns         6165 ns       111187 bytes_per_second=163.365M/s
+schwaemm192_192_decrypt/1024/32       6179 ns         6171 ns       113269 bytes_per_second=163.192M/s
+schwaemm192_192_encrypt/2048/32      11742 ns        11734 ns        59098 bytes_per_second=169.051M/s
+schwaemm192_192_decrypt/2048/32      11638 ns        11632 ns        58482 bytes_per_second=170.535M/s
+schwaemm192_192_encrypt/4096/32      22709 ns        22689 ns        30435 bytes_per_second=173.511M/s
+schwaemm192_192_decrypt/4096/32      22625 ns        22608 ns        30917 bytes_per_second=174.134M/s
+schwaemm128_128_encrypt/64/32          612 ns          612 ns      1108595 bytes_per_second=149.604M/s
+schwaemm128_128_decrypt/64/32          595 ns          594 ns      1146507 bytes_per_second=154.076M/s
+schwaemm128_128_encrypt/128/32         857 ns          856 ns       782936 bytes_per_second=178.211M/s
+schwaemm128_128_decrypt/128/32         828 ns          827 ns       833552 bytes_per_second=184.454M/s
+schwaemm128_128_encrypt/256/32        1353 ns         1352 ns       512138 bytes_per_second=203.193M/s
+schwaemm128_128_decrypt/256/32        1323 ns         1322 ns       528605 bytes_per_second=207.786M/s
+schwaemm128_128_encrypt/512/32        2344 ns         2341 ns       298139 bytes_per_second=221.633M/s
+schwaemm128_128_decrypt/512/32        2266 ns         2264 ns       303380 bytes_per_second=229.112M/s
+schwaemm128_128_encrypt/1024/32       4330 ns         4308 ns       159806 bytes_per_second=233.751M/s
+schwaemm128_128_decrypt/1024/32       4175 ns         4170 ns       166537 bytes_per_second=241.493M/s
+schwaemm128_128_encrypt/2048/32       8211 ns         8201 ns        82849 bytes_per_second=241.881M/s
+schwaemm128_128_decrypt/2048/32       8022 ns         8013 ns        85426 bytes_per_second=247.55M/s
+schwaemm128_128_encrypt/4096/32      16029 ns        16010 ns        42385 bytes_per_second=245.897M/s
+schwaemm128_128_decrypt/4096/32      15724 ns        15701 ns        44363 bytes_per_second=250.728M/s
+schwaemm256_256_encrypt/64/32         1035 ns         1034 ns       670440 bytes_per_second=88.5618M/s
+schwaemm256_256_decrypt/64/32         1055 ns         1054 ns       643276 bytes_per_second=86.8737M/s
+schwaemm256_256_encrypt/128/32        1409 ns         1407 ns       496817 bytes_per_second=108.443M/s
+schwaemm256_256_decrypt/128/32        1443 ns         1436 ns       480443 bytes_per_second=106.286M/s
+schwaemm256_256_encrypt/256/32        2162 ns         2160 ns       322889 bytes_per_second=127.144M/s
+schwaemm256_256_decrypt/256/32        2175 ns         2174 ns       319302 bytes_per_second=126.359M/s
+schwaemm256_256_encrypt/512/32        3656 ns         3651 ns       192493 bytes_per_second=142.105M/s
+schwaemm256_256_decrypt/512/32        3662 ns         3658 ns       191939 bytes_per_second=141.821M/s
+schwaemm256_256_encrypt/1024/32       6618 ns         6612 ns       102796 bytes_per_second=152.31M/s
+schwaemm256_256_decrypt/1024/32       6717 ns         6705 ns       103986 bytes_per_second=150.196M/s
+schwaemm256_256_encrypt/2048/32      12644 ns        12630 ns        54997 bytes_per_second=157.054M/s
+schwaemm256_256_decrypt/2048/32      12607 ns        12593 ns        53943 bytes_per_second=157.521M/s
+schwaemm256_256_encrypt/4096/32      24526 ns        24492 ns        28538 bytes_per_second=160.74M/s
+schwaemm256_256_decrypt/4096/32      24752 ns        24706 ns        28401 bytes_per_second=159.342M/s
 ```
 
 ## Usage
@@ -257,12 +191,17 @@ If you're interested in
 
 - Esch256 Hash, import `./include/esch256.hpp`
 - Esch384 Hash, import `./include/esch384.hpp`
+
+> Or just include `./include/esch.hpp` for Esch hashing
+
 - Schwaemm128-128 AEAD, import `./include/schwaemm128_128.hpp`
 - Schwaemm192-192 AEAD, import `./include/schwaemm192_192.hpp`
 - Schwaemm256-128 AEAD, import `./include/schwaemm256_128.hpp`
 - Schwaemm256-256 AEAD, import `./include/schwaemm256_256.hpp`
 
-I'm maintaining following examples for practically demonstrating usage of Sparkle C++ API.
+> Or just include `./include/schwaemm.hpp` for Schwaemm AEAD
 
-- For Esch{256, 384} Hash, see [here](https://github.com/itzmeanjan/sparkle/blob/96c33f8/example/hash.cpp)
-- For Schwaemm{128, 192, 256}-{128, 192, 256} AEAD, see [here](https://github.com/itzmeanjan/sparkle/blob/96c33f8/example/aead.cpp)
+I strongly advise you to go through following examples, where I demonstrate usage of Sparkle C++ API.
+
+- For Esch{256, 384} Hash, see [here](./example/hash.cpp)
+- For Schwaemm{128, 192, 256}-{128, 192, 256} AEAD, see [here](./example/aead.cpp)

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -1,5 +1,4 @@
-#include "bench_aead.hpp"
-#include "bench_hash.hpp"
+#include "bench/bench_sparkle.hpp"
 
 // registering Esch{256,384} functions for benchmark
 BENCHMARK(esch256_hash)->Arg(64);

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -28,74 +28,74 @@ BENCHMARK(esch384_hash)->Arg(4096);
 // registering Schwaemm256-128 AEAD encrypt/ decrypt routines for benchmark
 //
 // note, associated data size is set to be 32 -bytes for all cases
-BENCHMARK(schwaemm256_128_encrypt)->Args({64, 32});
-BENCHMARK(schwaemm256_128_decrypt)->Args({64, 32});
-BENCHMARK(schwaemm256_128_encrypt)->Args({128, 32});
-BENCHMARK(schwaemm256_128_decrypt)->Args({128, 32});
-BENCHMARK(schwaemm256_128_encrypt)->Args({256, 32});
-BENCHMARK(schwaemm256_128_decrypt)->Args({256, 32});
-BENCHMARK(schwaemm256_128_encrypt)->Args({512, 32});
-BENCHMARK(schwaemm256_128_decrypt)->Args({512, 32});
-BENCHMARK(schwaemm256_128_encrypt)->Args({1024, 32});
-BENCHMARK(schwaemm256_128_decrypt)->Args({1024, 32});
-BENCHMARK(schwaemm256_128_encrypt)->Args({2048, 32});
-BENCHMARK(schwaemm256_128_decrypt)->Args({2048, 32});
-BENCHMARK(schwaemm256_128_encrypt)->Args({4096, 32});
-BENCHMARK(schwaemm256_128_decrypt)->Args({4096, 32});
+BENCHMARK(schwaemm256_128_encrypt)->Args({ 64, 32 });
+BENCHMARK(schwaemm256_128_decrypt)->Args({ 64, 32 });
+BENCHMARK(schwaemm256_128_encrypt)->Args({ 128, 32 });
+BENCHMARK(schwaemm256_128_decrypt)->Args({ 128, 32 });
+BENCHMARK(schwaemm256_128_encrypt)->Args({ 256, 32 });
+BENCHMARK(schwaemm256_128_decrypt)->Args({ 256, 32 });
+BENCHMARK(schwaemm256_128_encrypt)->Args({ 512, 32 });
+BENCHMARK(schwaemm256_128_decrypt)->Args({ 512, 32 });
+BENCHMARK(schwaemm256_128_encrypt)->Args({ 1024, 32 });
+BENCHMARK(schwaemm256_128_decrypt)->Args({ 1024, 32 });
+BENCHMARK(schwaemm256_128_encrypt)->Args({ 2048, 32 });
+BENCHMARK(schwaemm256_128_decrypt)->Args({ 2048, 32 });
+BENCHMARK(schwaemm256_128_encrypt)->Args({ 4096, 32 });
+BENCHMARK(schwaemm256_128_decrypt)->Args({ 4096, 32 });
 
 // registering Schwaemm192-192 AEAD encrypt/ decrypt routines for benchmark
 //
 // note, associated data size is set to be 32 -bytes for all cases
-BENCHMARK(schwaemm192_192_encrypt)->Args({64, 32});
-BENCHMARK(schwaemm192_192_decrypt)->Args({64, 32});
-BENCHMARK(schwaemm192_192_encrypt)->Args({128, 32});
-BENCHMARK(schwaemm192_192_decrypt)->Args({128, 32});
-BENCHMARK(schwaemm192_192_encrypt)->Args({256, 32});
-BENCHMARK(schwaemm192_192_decrypt)->Args({256, 32});
-BENCHMARK(schwaemm192_192_encrypt)->Args({512, 32});
-BENCHMARK(schwaemm192_192_decrypt)->Args({512, 32});
-BENCHMARK(schwaemm192_192_encrypt)->Args({1024, 32});
-BENCHMARK(schwaemm192_192_decrypt)->Args({1024, 32});
-BENCHMARK(schwaemm192_192_encrypt)->Args({2048, 32});
-BENCHMARK(schwaemm192_192_decrypt)->Args({2048, 32});
-BENCHMARK(schwaemm192_192_encrypt)->Args({4096, 32});
-BENCHMARK(schwaemm192_192_decrypt)->Args({4096, 32});
+BENCHMARK(schwaemm192_192_encrypt)->Args({ 64, 32 });
+BENCHMARK(schwaemm192_192_decrypt)->Args({ 64, 32 });
+BENCHMARK(schwaemm192_192_encrypt)->Args({ 128, 32 });
+BENCHMARK(schwaemm192_192_decrypt)->Args({ 128, 32 });
+BENCHMARK(schwaemm192_192_encrypt)->Args({ 256, 32 });
+BENCHMARK(schwaemm192_192_decrypt)->Args({ 256, 32 });
+BENCHMARK(schwaemm192_192_encrypt)->Args({ 512, 32 });
+BENCHMARK(schwaemm192_192_decrypt)->Args({ 512, 32 });
+BENCHMARK(schwaemm192_192_encrypt)->Args({ 1024, 32 });
+BENCHMARK(schwaemm192_192_decrypt)->Args({ 1024, 32 });
+BENCHMARK(schwaemm192_192_encrypt)->Args({ 2048, 32 });
+BENCHMARK(schwaemm192_192_decrypt)->Args({ 2048, 32 });
+BENCHMARK(schwaemm192_192_encrypt)->Args({ 4096, 32 });
+BENCHMARK(schwaemm192_192_decrypt)->Args({ 4096, 32 });
 
 // registering Schwaemm128-128 AEAD encrypt/ decrypt routines for benchmark
 //
 // note, associated data size is set to be 32 -bytes for all cases
-BENCHMARK(schwaemm128_128_encrypt)->Args({64, 32});
-BENCHMARK(schwaemm128_128_decrypt)->Args({64, 32});
-BENCHMARK(schwaemm128_128_encrypt)->Args({128, 32});
-BENCHMARK(schwaemm128_128_decrypt)->Args({128, 32});
-BENCHMARK(schwaemm128_128_encrypt)->Args({256, 32});
-BENCHMARK(schwaemm128_128_decrypt)->Args({256, 32});
-BENCHMARK(schwaemm128_128_encrypt)->Args({512, 32});
-BENCHMARK(schwaemm128_128_decrypt)->Args({512, 32});
-BENCHMARK(schwaemm128_128_encrypt)->Args({1024, 32});
-BENCHMARK(schwaemm128_128_decrypt)->Args({1024, 32});
-BENCHMARK(schwaemm128_128_encrypt)->Args({2048, 32});
-BENCHMARK(schwaemm128_128_decrypt)->Args({2048, 32});
-BENCHMARK(schwaemm128_128_encrypt)->Args({4096, 32});
-BENCHMARK(schwaemm128_128_decrypt)->Args({4096, 32});
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 64, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 64, 32 });
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 128, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 128, 32 });
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 256, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 256, 32 });
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 512, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 512, 32 });
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 1024, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 1024, 32 });
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 2048, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 2048, 32 });
+BENCHMARK(schwaemm128_128_encrypt)->Args({ 4096, 32 });
+BENCHMARK(schwaemm128_128_decrypt)->Args({ 4096, 32 });
 
 // registering Schwaemm256-256 AEAD encrypt/ decrypt routines for benchmark
 //
 // note, associated data size is set to be 32 -bytes for all cases
-BENCHMARK(schwaemm256_256_encrypt)->Args({64, 32});
-BENCHMARK(schwaemm256_256_decrypt)->Args({64, 32});
-BENCHMARK(schwaemm256_256_encrypt)->Args({128, 32});
-BENCHMARK(schwaemm256_256_decrypt)->Args({128, 32});
-BENCHMARK(schwaemm256_256_encrypt)->Args({256, 32});
-BENCHMARK(schwaemm256_256_decrypt)->Args({256, 32});
-BENCHMARK(schwaemm256_256_encrypt)->Args({512, 32});
-BENCHMARK(schwaemm256_256_decrypt)->Args({512, 32});
-BENCHMARK(schwaemm256_256_encrypt)->Args({1024, 32});
-BENCHMARK(schwaemm256_256_decrypt)->Args({1024, 32});
-BENCHMARK(schwaemm256_256_encrypt)->Args({2048, 32});
-BENCHMARK(schwaemm256_256_decrypt)->Args({2048, 32});
-BENCHMARK(schwaemm256_256_encrypt)->Args({4096, 32});
-BENCHMARK(schwaemm256_256_decrypt)->Args({4096, 32});
+BENCHMARK(schwaemm256_256_encrypt)->Args({ 64, 32 });
+BENCHMARK(schwaemm256_256_decrypt)->Args({ 64, 32 });
+BENCHMARK(schwaemm256_256_encrypt)->Args({ 128, 32 });
+BENCHMARK(schwaemm256_256_decrypt)->Args({ 128, 32 });
+BENCHMARK(schwaemm256_256_encrypt)->Args({ 256, 32 });
+BENCHMARK(schwaemm256_256_decrypt)->Args({ 256, 32 });
+BENCHMARK(schwaemm256_256_encrypt)->Args({ 512, 32 });
+BENCHMARK(schwaemm256_256_decrypt)->Args({ 512, 32 });
+BENCHMARK(schwaemm256_256_encrypt)->Args({ 1024, 32 });
+BENCHMARK(schwaemm256_256_decrypt)->Args({ 1024, 32 });
+BENCHMARK(schwaemm256_256_encrypt)->Args({ 2048, 32 });
+BENCHMARK(schwaemm256_256_decrypt)->Args({ 2048, 32 });
+BENCHMARK(schwaemm256_256_encrypt)->Args({ 4096, 32 });
+BENCHMARK(schwaemm256_256_decrypt)->Args({ 4096, 32 });
 
 // main function to drive execution of benchmark
 BENCHMARK_MAIN();

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -1,5 +1,13 @@
 #include "bench/bench_sparkle.hpp"
 
+// registering Sparkle{256, 384, 512}'s slim/ big variant for benchmarking
+BENCHMARK(bench_sparkle::sparkle<4, 7>);
+BENCHMARK(bench_sparkle::sparkle<4, 10>);
+BENCHMARK(bench_sparkle::sparkle<6, 7>);
+BENCHMARK(bench_sparkle::sparkle<6, 11>);
+BENCHMARK(bench_sparkle::sparkle<8, 8>);
+BENCHMARK(bench_sparkle::sparkle<8, 12>);
+
 // registering Esch{256,384} functions for benchmark
 BENCHMARK(esch256_hash)->Arg(64);
 BENCHMARK(esch256_hash)->Arg(128);

--- a/example/aead.cpp
+++ b/example/aead.cpp
@@ -8,7 +8,7 @@
 
 // Compile it with
 //
-// g++ -std=c++20 -Wall -I ./include example/aead.cpp
+// g++ -std=c++20 -Wall -O3 -I ./include example/aead.cpp
 int
 main()
 {
@@ -20,21 +20,22 @@ main()
   uint8_t enc[ct_len];
   uint8_t dec[ct_len];
 
-  random_data(data, d_len); // generate random associated data
-  random_data(txt, d_len);  // generate random plain text
+  sparkle_utils::random_data(data, d_len); // generate random associated data
+  sparkle_utils::random_data(txt, d_len);  // generate random plain text
 
-  std::cout << "data = " << to_hex(data, sizeof(data)) << std::endl;
-  std::cout << "text = " << to_hex(txt, sizeof(txt)) << std::endl;
+  std::cout << "data = " << sparkle_utils::to_hex(data, sizeof(data)) << "\n";
+  std::cout << "text = " << sparkle_utils::to_hex(txt, sizeof(txt)) << "\n";
 
   {
-    std::cout << "\nSchwaemm128-128 AEAD\n" << std::endl;
+    std::cout << "\nSchwaemm128-128 AEAD\n"
+              << "\n";
 
     uint8_t key[schwaemm128_128::C];
     uint8_t nonce[schwaemm128_128::R];
     uint8_t tag[schwaemm128_128::C];
 
-    random_data(key, sizeof(key));
-    random_data(nonce, sizeof(nonce));
+    sparkle_utils::random_data(key, sizeof(key));
+    sparkle_utils::random_data(nonce, sizeof(nonce));
 
     std::memset(enc, 0, sizeof(enc));
     std::memset(dec, 0, sizeof(dec));
@@ -55,22 +56,23 @@ main()
 
     assert(!cmp);
 
-    std::cout << "key           = " << to_hex(key, sizeof(key)) << std::endl;
-    std::cout << "nonce         = " << to_hex(nonce, sizeof(nonce))
-              << std::endl;
-    std::cout << "cipher        = " << to_hex(enc, sizeof(enc)) << std::endl;
-    std::cout << "decrypted     = " << to_hex(dec, sizeof(dec)) << std::endl;
+    using namespace sparkle_utils;
+    std::cout << "key           = " << to_hex(key, sizeof(key)) << "\n";
+    std::cout << "nonce         = " << to_hex(nonce, sizeof(nonce)) << "\n";
+    std::cout << "cipher        = " << to_hex(enc, sizeof(enc)) << "\n";
+    std::cout << "decrypted     = " << to_hex(dec, sizeof(dec)) << "\n";
   }
 
   {
-    std::cout << "\nSchwaemm192-192 AEAD\n" << std::endl;
+    std::cout << "\nSchwaemm192-192 AEAD\n"
+              << "\n";
 
     uint8_t key[schwaemm192_192::C];
     uint8_t nonce[schwaemm192_192::R];
     uint8_t tag[schwaemm192_192::C];
 
-    random_data(key, sizeof(key));
-    random_data(nonce, sizeof(nonce));
+    sparkle_utils::random_data(key, sizeof(key));
+    sparkle_utils::random_data(nonce, sizeof(nonce));
 
     std::memset(enc, 0, sizeof(enc));
     std::memset(dec, 0, sizeof(dec));
@@ -91,22 +93,23 @@ main()
 
     assert(!cmp);
 
-    std::cout << "key           = " << to_hex(key, sizeof(key)) << std::endl;
-    std::cout << "nonce         = " << to_hex(nonce, sizeof(nonce))
-              << std::endl;
-    std::cout << "cipher        = " << to_hex(enc, sizeof(enc)) << std::endl;
-    std::cout << "decrypted     = " << to_hex(dec, sizeof(dec)) << std::endl;
+    using namespace sparkle_utils;
+    std::cout << "key           = " << to_hex(key, sizeof(key)) << "\n";
+    std::cout << "nonce         = " << to_hex(nonce, sizeof(nonce)) << "\n";
+    std::cout << "cipher        = " << to_hex(enc, sizeof(enc)) << "\n";
+    std::cout << "decrypted     = " << to_hex(dec, sizeof(dec)) << "\n";
   }
 
   {
-    std::cout << "\nSchwaemm256-128 AEAD\n" << std::endl;
+    std::cout << "\nSchwaemm256-128 AEAD\n"
+              << "\n";
 
     uint8_t key[schwaemm256_128::C];
     uint8_t nonce[schwaemm256_128::R];
     uint8_t tag[schwaemm256_128::C];
 
-    random_data(key, sizeof(key));
-    random_data(nonce, sizeof(nonce));
+    sparkle_utils::random_data(key, sizeof(key));
+    sparkle_utils::random_data(nonce, sizeof(nonce));
 
     std::memset(enc, 0, sizeof(enc));
     std::memset(dec, 0, sizeof(dec));
@@ -127,22 +130,23 @@ main()
 
     assert(!cmp);
 
-    std::cout << "key           = " << to_hex(key, sizeof(key)) << std::endl;
-    std::cout << "nonce         = " << to_hex(nonce, sizeof(nonce))
-              << std::endl;
-    std::cout << "cipher        = " << to_hex(enc, sizeof(enc)) << std::endl;
-    std::cout << "decrypted     = " << to_hex(dec, sizeof(dec)) << std::endl;
+    using namespace sparkle_utils;
+    std::cout << "key           = " << to_hex(key, sizeof(key)) << "\n";
+    std::cout << "nonce         = " << to_hex(nonce, sizeof(nonce)) << "\n";
+    std::cout << "cipher        = " << to_hex(enc, sizeof(enc)) << "\n";
+    std::cout << "decrypted     = " << to_hex(dec, sizeof(dec)) << "\n";
   }
 
   {
-    std::cout << "\nSchwaemm256-256 AEAD\n" << std::endl;
+    std::cout << "\nSchwaemm256-256 AEAD\n"
+              << "\n";
 
     uint8_t key[schwaemm256_256::C];
     uint8_t nonce[schwaemm256_256::R];
     uint8_t tag[schwaemm256_256::C];
 
-    random_data(key, sizeof(key));
-    random_data(nonce, sizeof(nonce));
+    sparkle_utils::random_data(key, sizeof(key));
+    sparkle_utils::random_data(nonce, sizeof(nonce));
 
     std::memset(enc, 0, sizeof(enc));
     std::memset(dec, 0, sizeof(dec));
@@ -163,11 +167,11 @@ main()
 
     assert(!cmp);
 
-    std::cout << "key           = " << to_hex(key, sizeof(key)) << std::endl;
-    std::cout << "nonce         = " << to_hex(nonce, sizeof(nonce))
-              << std::endl;
-    std::cout << "cipher        = " << to_hex(enc, sizeof(enc)) << std::endl;
-    std::cout << "decrypted     = " << to_hex(dec, sizeof(dec)) << std::endl;
+    using namespace sparkle_utils;
+    std::cout << "key           = " << to_hex(key, sizeof(key)) << "\n";
+    std::cout << "nonce         = " << to_hex(nonce, sizeof(nonce)) << "\n";
+    std::cout << "cipher        = " << to_hex(enc, sizeof(enc)) << "\n";
+    std::cout << "decrypted     = " << to_hex(dec, sizeof(dec)) << "\n";
   }
 
   return EXIT_SUCCESS;

--- a/example/aead.cpp
+++ b/example/aead.cpp
@@ -1,10 +1,6 @@
+#include "schwaemm.hpp"
 #include <cassert>
 #include <iostream>
-
-#include "schwaemm128_128.hpp"
-#include "schwaemm192_192.hpp"
-#include "schwaemm256_128.hpp"
-#include "schwaemm256_256.hpp"
 
 // Compile it with
 //

--- a/example/aead.cpp
+++ b/example/aead.cpp
@@ -9,19 +9,17 @@
 // Compile it with
 //
 // g++ -std=c++20 -Wall -I ./include example/aead.cpp
-int
-main()
-{
-  constexpr size_t d_len = 32ul;  // associate data byte length
-  constexpr size_t ct_len = 32ul; // plain/ cipher text byte length
+int main() {
+  constexpr size_t d_len = 32ul;   // associate data byte length
+  constexpr size_t ct_len = 32ul;  // plain/ cipher text byte length
 
   uint8_t data[d_len];
   uint8_t txt[ct_len];
   uint8_t enc[ct_len];
   uint8_t dec[ct_len];
 
-  random_data(data, d_len); // generate random associated data
-  random_data(txt, d_len);  // generate random plain text
+  random_data(data, d_len);  // generate random associated data
+  random_data(txt, d_len);   // generate random plain text
 
   std::cout << "data = " << to_hex(data, sizeof(data)) << std::endl;
   std::cout << "text = " << to_hex(txt, sizeof(txt)) << std::endl;

--- a/example/aead.cpp
+++ b/example/aead.cpp
@@ -9,17 +9,19 @@
 // Compile it with
 //
 // g++ -std=c++20 -Wall -I ./include example/aead.cpp
-int main() {
-  constexpr size_t d_len = 32ul;   // associate data byte length
-  constexpr size_t ct_len = 32ul;  // plain/ cipher text byte length
+int
+main()
+{
+  constexpr size_t d_len = 32ul;  // associate data byte length
+  constexpr size_t ct_len = 32ul; // plain/ cipher text byte length
 
   uint8_t data[d_len];
   uint8_t txt[ct_len];
   uint8_t enc[ct_len];
   uint8_t dec[ct_len];
 
-  random_data(data, d_len);  // generate random associated data
-  random_data(txt, d_len);   // generate random plain text
+  random_data(data, d_len); // generate random associated data
+  random_data(txt, d_len);  // generate random plain text
 
   std::cout << "data = " << to_hex(data, sizeof(data)) << std::endl;
   std::cout << "text = " << to_hex(txt, sizeof(txt)) << std::endl;

--- a/example/hash.cpp
+++ b/example/hash.cpp
@@ -1,7 +1,5 @@
+#include "esch.hpp"
 #include <iostream>
-
-#include "esch256.hpp"
-#include "esch384.hpp"
 
 // Compile it with
 //

--- a/example/hash.cpp
+++ b/example/hash.cpp
@@ -6,8 +6,10 @@
 // Compile it with
 //
 // g++ -std=c++20 -Wall -I ./include example/hash.cpp
-int main() {
-  constexpr size_t d_len = 32ul;  // message length in bytes
+int
+main()
+{
+  constexpr size_t d_len = 32ul; // message length in bytes
 
   uint8_t data[d_len];
   uint8_t dig0[32];

--- a/example/hash.cpp
+++ b/example/hash.cpp
@@ -6,10 +6,8 @@
 // Compile it with
 //
 // g++ -std=c++20 -Wall -I ./include example/hash.cpp
-int
-main()
-{
-  constexpr size_t d_len = 32ul; // message length in bytes
+int main() {
+  constexpr size_t d_len = 32ul;  // message length in bytes
 
   uint8_t data[d_len];
   uint8_t dig0[32];

--- a/example/hash.cpp
+++ b/example/hash.cpp
@@ -5,18 +5,18 @@
 
 // Compile it with
 //
-// g++ -std=c++20 -Wall -I ./include example/hash.cpp
+// g++ -std=c++20 -Wall -O3 -I ./include example/hash.cpp
 int
 main()
 {
   constexpr size_t d_len = 32ul; // message length in bytes
 
   uint8_t data[d_len];
-  uint8_t dig0[32];
-  uint8_t dig1[48];
+  uint8_t dig0[esch256::DIGEST_LEN];
+  uint8_t dig1[esch384::DIGEST_LEN];
 
   // random message bytes
-  random_data(data, d_len);
+  sparkle_utils::random_data(data, d_len);
 
   std::memset(dig0, 0, sizeof(dig0));
   std::memset(dig1, 0, sizeof(dig1));
@@ -26,6 +26,7 @@ main()
   // compute Esch384 digest
   esch384::hash(data, d_len, dig1);
 
+  using namespace sparkle_utils;
   std::cout << "esch256( " << to_hex(data, d_len)
             << " ) = " << to_hex(dig0, sizeof(dig0)) << std::endl;
 

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -398,6 +398,7 @@ process_data(
   constexpr size_t RATE_W = RATE >> 2; // # -of 32 -bit words
   uint32_t buffer0[RATE_W + 1];
 
+  // process full message blocks, except last one ( even if that's full )
   size_t r_bytes = d_len;
   while (r_bytes > RATE) {
     const size_t b_off = d_len - r_bytes;
@@ -410,6 +411,7 @@ process_data(
     r_bytes -= RATE;
   }
 
+  // process last message block, it can be full/ partially filled
   size_t b_off = d_len - r_bytes;
 
   const size_t rb_full_words = r_bytes >> 2;
@@ -458,6 +460,7 @@ process_text(uint32_t* const __restrict state,    // permutation state
   uint32_t buffer0[RATE_W + 1];
   uint32_t buffer1[RATE_W];
 
+  // process full message blocks, except last one ( even if that's full )
   size_t r_bytes = ct_len;
   while (r_bytes > RATE) {
     const size_t b_off = ct_len - r_bytes;
@@ -474,6 +477,7 @@ process_text(uint32_t* const __restrict state,    // permutation state
     r_bytes -= RATE;
   }
 
+  // process last message block, it can be full/ partially filled
   size_t b_off = ct_len - r_bytes;
 
   const size_t rb_full_words = r_bytes >> 2;
@@ -529,6 +533,7 @@ process_cipher(
   uint32_t buffer0[RATE_W + 1];
   uint32_t buffer1[RATE_W];
 
+  // process full message blocks, except last one ( even if that's full )
   size_t r_bytes = ct_len;
   while (r_bytes > RATE) {
     const size_t b_off = ct_len - r_bytes;
@@ -545,6 +550,7 @@ process_cipher(
     r_bytes -= RATE;
   }
 
+  // process last message block, it can be full/ partially filled
   size_t b_off = ct_len - r_bytes;
 
   const size_t rb_full_words = r_bytes >> 2;
@@ -568,6 +574,7 @@ process_cipher(
   sparkle_utils::copy_words_to_le_bytes(buffer1, dec + b_off, r_bytes);
   b_off += rb_full_bytes;
 
+  // in case last message block is not full
   if (r_bytes < RATE) {
     std::memset(buffer1 + rb_full_words, 0, RATE - rb_full_bytes);
 
@@ -576,7 +583,9 @@ process_cipher(
     buffer1[rb_full_words] = word;
 
     rho1<RATE>(state, buffer1);
-  } else {
+  }
+  // when last message block is full
+  else {
     rhoprime1<RATE>(state, buffer0);
   }
 

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -1016,6 +1016,9 @@ decrypt(const uint8_t* const __restrict key,   // C -bytes secret key
   for (size_t i = 0; i < C; i++) {
     flag |= (tag[i] ^ tag_[i]);
   }
+
+  // don't release unverified plain text
+  std::memset(dec, 0, flag * ct_len);
   return !flag;
 }
 

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -79,32 +79,83 @@ initialize(
 // To be more specific, `s` is actually outer part of permutation state !
 template<const size_t RATE>
 static inline void
-feistel_swap(uint32_t* const __restrict s)
+feistel_swap(uint32_t* const s)
 {
   if constexpr ((RATE ^ 32ul) == 0) {
-    std::swap(s[0], s[4]);
-    std::swap(s[1], s[5]);
-    std::swap(s[2], s[6]);
-    std::swap(s[3], s[7]);
+    static_assert(RATE == 32, "Rate must be = 32 -bytes");
 
-    s[4] ^= s[0];
-    s[5] ^= s[1];
-    s[6] ^= s[2];
-    s[7] ^= s[3];
+#if defined __clang__
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#elif defined __GNUG__
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
+#pragma GCC unroll 4
+#endif
+    for (size_t i = 0; i < 4; i++) {
+      // swap
+      s[i] ^= s[4 + i];
+      s[4 + i] ^= s[i];
+      s[i] ^= s[4 + i];
+
+      // xor
+      s[4 + i] ^= s[i];
+    }
   } else if constexpr ((RATE ^ 24ul) == 0) {
-    std::swap(s[0], s[3]);
-    std::swap(s[1], s[4]);
-    std::swap(s[2], s[5]);
+    static_assert(RATE == 24, "Rate must be = 24 -bytes");
 
-    s[3] ^= s[0];
-    s[4] ^= s[1];
-    s[5] ^= s[2];
-  } else if constexpr ((RATE ^ 16ul) == 0) {
-    std::swap(s[0], s[2]);
-    std::swap(s[1], s[3]);
+#if defined __clang__
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
 
-    s[2] ^= s[0];
-    s[3] ^= s[1];
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#elif defined __GNUG__
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
+#pragma GCC unroll 3
+#endif
+    for (size_t i = 0; i < 3; i++) {
+      // swap
+      s[i] ^= s[3 + i];
+      s[3 + i] ^= s[i];
+      s[i] ^= s[3 + i];
+
+      // xor
+      s[3 + i] ^= s[i];
+    }
+  } else {
+    static_assert(RATE == 16, "Rate must be = 16 -bytes");
+
+#if defined __clang__
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#elif defined __GNUG__
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
+#pragma GCC unroll 2
+#endif
+    for (size_t i = 0; i < 2; i++) {
+      // swap
+      s[i] ^= s[2 + i];
+      s[2 + i] ^= s[i];
+      s[i] ^= s[2 + i];
+
+      // xor
+      s[2 + i] ^= s[i];
+    }
   }
 }
 

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -170,17 +170,68 @@ rho1(uint32_t* const __restrict s,      // RATE -bytes wide
      const uint32_t* const __restrict d // RATE -bytes wide
 )
 {
-  constexpr size_t RATE_W = RATE >> 2; // # -of 32 -bit words
-
   feistel_swap<RATE>(s);
 
+  if constexpr (RATE == 16) {
+    static_assert(RATE == 16, "Rate must be = 16 -bytes");
+    constexpr size_t RATE_W = RATE >> 2;
+
 #if defined __clang__
-#pragma unroll
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
 #elif defined __GNUG__
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
 #pragma GCC ivdep
+#pragma GCC unroll 4
 #endif
-  for (size_t i = 0; i < RATE_W; i++) {
-    s[i] ^= d[i];
+    for (size_t i = 0; i < RATE_W; i++) {
+      s[i] ^= d[i];
+    }
+  } else if constexpr (RATE == 24) {
+    static_assert(RATE == 24, "Rate must be = 24 -bytes");
+    constexpr size_t RATE_W = RATE >> 2;
+
+#if defined __clang__
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#elif defined __GNUG__
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
+#pragma GCC unroll 6
+#endif
+    for (size_t i = 0; i < RATE_W; i++) {
+      s[i] ^= d[i];
+    }
+  } else {
+    static_assert(RATE == 32, "Rate must be = 32 -bytes");
+    constexpr size_t RATE_W = RATE >> 2;
+
+#if defined __clang__
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#elif defined __GNUG__
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
+#pragma GCC unroll 8
+#endif
+    for (size_t i = 0; i < RATE_W; i++) {
+      s[i] ^= d[i];
+    }
   }
 }
 

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -27,7 +27,7 @@ initialize(
   constexpr size_t RATE_W = RATE >> 2;         // # -of 32 -bit words
   constexpr size_t CAPACITY_W = CAPACITY >> 2; // # -of 32 -bit words
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(state, nonce, RATE);
   } else {
 #if defined __clang__
@@ -45,7 +45,7 @@ initialize(
     }
   }
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(state + RATE_W, key, CAPACITY);
   } else {
 #if defined __clang__
@@ -247,7 +247,7 @@ process_data(
   while (r_bytes > RATE) {
     const size_t b_off = d_len - r_bytes;
 
-    if constexpr (is_little_endian()) {
+    if constexpr (sparkle_utils::is_little_endian()) {
       std::memcpy(buffer0, data + b_off, RATE);
     } else {
 #if defined __clang__
@@ -300,7 +300,7 @@ process_data(
 
   std::memset(buffer0, 0, RATE);
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(buffer0, data + b_off, rb_full_words << 2);
   } else {
     for (size_t i = 0; i < rb_full_words; i++) {
@@ -381,7 +381,7 @@ process_text(uint32_t* const __restrict state,    // permutation state
   while (r_bytes > RATE) {
     const size_t b_off = ct_len - r_bytes;
 
-    if constexpr (is_little_endian()) {
+    if constexpr (sparkle_utils::is_little_endian()) {
       std::memcpy(buffer0, txt + b_off, RATE);
     } else {
 #if defined __clang__
@@ -402,7 +402,7 @@ process_text(uint32_t* const __restrict state,    // permutation state
     std::memcpy(buffer2, state, RATE);
     rho2<RATE>(buffer2, buffer0);
 
-    if constexpr (is_little_endian()) {
+    if constexpr (sparkle_utils::is_little_endian()) {
       std::memcpy(enc + b_off, buffer2, RATE);
     } else {
 #if defined __clang__
@@ -456,7 +456,7 @@ process_text(uint32_t* const __restrict state,    // permutation state
 
   std::memset(buffer0, 0, RATE);
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(buffer0, txt + b_off, rb_full_words << 2);
   } else {
     for (size_t i = 0; i < rb_full_words; i++) {
@@ -482,7 +482,7 @@ process_text(uint32_t* const __restrict state,    // permutation state
   std::memcpy(buffer2, state, RATE);
   rho2<RATE>(buffer2, buffer0);
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(enc + b_off, buffer2, rb_full_words << 2);
   } else {
     for (size_t i = 0; i < rb_full_words; i++) {
@@ -560,7 +560,7 @@ process_cipher(
   while (r_bytes > RATE) {
     const size_t b_off = ct_len - r_bytes;
 
-    if constexpr (is_little_endian()) {
+    if constexpr (sparkle_utils::is_little_endian()) {
       std::memcpy(buffer0, enc + b_off, RATE);
     } else {
 #if defined __clang__
@@ -581,7 +581,7 @@ process_cipher(
     std::memcpy(buffer2, state, RATE);
     rhoprime2<RATE>(buffer2, buffer0);
 
-    if constexpr (is_little_endian()) {
+    if constexpr (sparkle_utils::is_little_endian()) {
       std::memcpy(dec + b_off, buffer2, RATE);
     } else {
 #if defined __clang__
@@ -635,7 +635,7 @@ process_cipher(
 
   std::memset(buffer0, 0, RATE);
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(buffer0, enc + b_off, rb_full_words << 2);
   } else {
     for (size_t i = 0; i < rb_full_words; i++) {
@@ -661,7 +661,7 @@ process_cipher(
   std::memcpy(buffer2, state, RATE);
   rhoprime2<RATE>(buffer2, buffer0);
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(dec + b_off, buffer2, rb_full_words << 2);
   } else {
     for (size_t i = 0; i < rb_full_words; i++) {
@@ -743,7 +743,7 @@ finalize(const uint32_t* const __restrict state, // permutation state
 
   uint32_t buffer[CAPACITY_W];
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(buffer, key, CAPACITY);
   } else {
 #if defined __clang__
@@ -761,7 +761,7 @@ finalize(const uint32_t* const __restrict state, // permutation state
     }
   }
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
 #if defined __clang__
 #pragma unroll
 #elif defined __GNUG__

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -159,19 +159,17 @@ feistel_swap(uint32_t* const s)
   }
 }
 
-// Feedback function `𝜌1`, used during SchwaemmX-Y Authenticated
+// Feedback function `𝜌2`, used during SchwaemmX-Y Authenticated
 // Encryption | X, Y ∈ {128, 192, 256}
 //
 // See section 2.3.2 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
 template<const size_t RATE>
 static inline void
-rho1(uint32_t* const __restrict s,      // RATE -bytes wide
+rho2(uint32_t* const __restrict s,      // RATE -bytes wide
      const uint32_t* const __restrict d // RATE -bytes wide
 )
 {
-  feistel_swap<RATE>(s);
-
   if constexpr (RATE == 16) {
     static_assert(RATE == 16, "Rate must be = 16 -bytes");
     constexpr size_t RATE_W = RATE >> 2;
@@ -235,27 +233,19 @@ rho1(uint32_t* const __restrict s,      // RATE -bytes wide
   }
 }
 
-// Feedback function `𝜌2`, used during SchwaemmX-Y Authenticated
+// Feedback function `𝜌1`, used during SchwaemmX-Y Authenticated
 // Encryption | X, Y ∈ {128, 192, 256}
 //
 // See section 2.3.2 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
 template<const size_t RATE>
 static inline void
-rho2(uint32_t* const __restrict s,      // RATE -bytes wide
+rho1(uint32_t* const __restrict s,      // RATE -bytes wide
      const uint32_t* const __restrict d // RATE -bytes wide
 )
 {
-  constexpr size_t RATE_W = RATE >> 2; // # -of 32 -bit words
-
-#if defined __clang__
-#pragma unroll
-#elif defined __GNUG__
-#pragma GCC ivdep
-#endif
-  for (size_t i = 0; i < RATE_W; i++) {
-    s[i] ^= d[i];
-  }
+  feistel_swap<RATE>(s);
+  rho2<RATE>(s, d);
 }
 
 // Inverse Feedback function `𝜌'1`, used during SchwaemmX-Y Verified

--- a/include/aead.hpp
+++ b/include/aead.hpp
@@ -13,15 +13,19 @@ namespace aead {
 //
 // See algorithm 2.13 in Sparkle specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-template <const size_t RATE, const size_t CAPACITY, const size_t nb,
-          const size_t ns>
-static inline void initialize(
-    uint32_t* const __restrict state,     // ((RATE + CAPACITY) << 3) -bit state
-    const uint8_t* const __restrict key,  // CAPACITY -bytes secret key
-    const uint8_t* const __restrict nonce  // RATE -bytes nonce
-) {
-  constexpr size_t RATE_W = RATE >> 2;          // # -of 32 -bit words
-  constexpr size_t CAPACITY_W = CAPACITY >> 2;  // # -of 32 -bit words
+template<const size_t RATE,
+         const size_t CAPACITY,
+         const size_t nb,
+         const size_t ns>
+static inline void
+initialize(
+  uint32_t* const __restrict state,     // ((RATE + CAPACITY) << 3) -bit state
+  const uint8_t* const __restrict key,  // CAPACITY -bytes secret key
+  const uint8_t* const __restrict nonce // RATE -bytes nonce
+)
+{
+  constexpr size_t RATE_W = RATE >> 2;         // # -of 32 -bit words
+  constexpr size_t CAPACITY_W = CAPACITY >> 2; // # -of 32 -bit words
 
   if constexpr (is_little_endian()) {
     std::memcpy(state, nonce, RATE);
@@ -73,8 +77,10 @@ static inline void initialize(
 // `s1 || s2 = s` meaning |s1| = |s2| = (RATE >> 1) << 3 -bit
 //
 // To be more specific, `s` is actually outer part of permutation state !
-template <const size_t RATE>
-static inline void feistel_swap(uint32_t* const __restrict s) {
+template<const size_t RATE>
+static inline void
+feistel_swap(uint32_t* const __restrict s)
+{
   if constexpr ((RATE ^ 32ul) == 0) {
     std::swap(s[0], s[4]);
     std::swap(s[1], s[5]);
@@ -107,11 +113,13 @@ static inline void feistel_swap(uint32_t* const __restrict s) {
 //
 // See section 2.3.2 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-template <const size_t RATE>
-static inline void rho1(uint32_t* const __restrict s,       // RATE -bytes wide
-                        const uint32_t* const __restrict d  // RATE -bytes wide
-) {
-  constexpr size_t RATE_W = RATE >> 2;  // # -of 32 -bit words
+template<const size_t RATE>
+static inline void
+rho1(uint32_t* const __restrict s,      // RATE -bytes wide
+     const uint32_t* const __restrict d // RATE -bytes wide
+)
+{
+  constexpr size_t RATE_W = RATE >> 2; // # -of 32 -bit words
 
   feistel_swap<RATE>(s);
 
@@ -130,11 +138,13 @@ static inline void rho1(uint32_t* const __restrict s,       // RATE -bytes wide
 //
 // See section 2.3.2 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-template <const size_t RATE>
-static inline void rho2(uint32_t* const __restrict s,       // RATE -bytes wide
-                        const uint32_t* const __restrict d  // RATE -bytes wide
-) {
-  constexpr size_t RATE_W = RATE >> 2;  // # -of 32 -bit words
+template<const size_t RATE>
+static inline void
+rho2(uint32_t* const __restrict s,      // RATE -bytes wide
+     const uint32_t* const __restrict d // RATE -bytes wide
+)
+{
+  constexpr size_t RATE_W = RATE >> 2; // # -of 32 -bit words
 
 #if defined __clang__
 #pragma unroll
@@ -151,12 +161,13 @@ static inline void rho2(uint32_t* const __restrict s,       // RATE -bytes wide
 //
 // See section 2.3.2 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-template <const size_t RATE>
-static inline void rhoprime1(
-    uint32_t* const __restrict s,       // RATE -bytes wide
-    const uint32_t* const __restrict d  // RATE -bytes wide
-) {
-  constexpr size_t RATE_W = RATE >> 2;  // # -of 32 -bit words
+template<const size_t RATE>
+static inline void
+rhoprime1(uint32_t* const __restrict s,      // RATE -bytes wide
+          const uint32_t* const __restrict d // RATE -bytes wide
+)
+{
+  constexpr size_t RATE_W = RATE >> 2; // # -of 32 -bit words
 
   uint32_t s_[RATE_W];
   std::memcpy(s_, s, RATE);
@@ -178,12 +189,13 @@ static inline void rhoprime1(
 //
 // See section 2.3.2 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-template <const size_t RATE>
-static inline void rhoprime2(
-    uint32_t* const __restrict s,       // RATE -bytes wide
-    const uint32_t* const __restrict d  // RATE -bytes wide
-) {
-  constexpr size_t RATE_W = RATE >> 2;  // # -of 32 -bit words
+template<const size_t RATE>
+static inline void
+rhoprime2(uint32_t* const __restrict s,      // RATE -bytes wide
+          const uint32_t* const __restrict d // RATE -bytes wide
+)
+{
+  constexpr size_t RATE_W = RATE >> 2; // # -of 32 -bit words
 
 #if defined __clang__
 #pragma unroll
@@ -197,11 +209,13 @@ static inline void rhoprime2(
 
 // Rate whitening layer, applied to 128 -bit wide inner part of permutation
 // state, for Schwaemm256-128 AEAD
-template <const size_t CAPACITY>
-static inline void omega(const uint32_t* const __restrict in,  // 128 -bit
-                         uint32_t* const __restrict out        // 256 -bit
-) {
-  constexpr size_t CAPACITY_W = CAPACITY >> 2;  // # -of 32 -bit words
+template<const size_t CAPACITY>
+static inline void
+omega(const uint32_t* const __restrict in, // 128 -bit
+      uint32_t* const __restrict out       // 256 -bit
+)
+{
+  constexpr size_t CAPACITY_W = CAPACITY >> 2; // # -of 32 -bit words
 
   std::memcpy(out, in, CAPACITY);
   std::memcpy(out + CAPACITY_W, in, CAPACITY);
@@ -210,15 +224,21 @@ static inline void omega(const uint32_t* const __restrict in,  // 128 -bit
 // Generic routine for consuming non-empty associated data into permutation
 // state using algorithm 2.13 of Sparkle specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-template <const size_t RATE, const size_t CAPACITY, const uint32_t CONST_A0,
-          const uint32_t CONST_A1, const size_t nb, const size_t ns_slim,
-          const size_t ns_big>
-static inline void process_data(
-    uint32_t* const __restrict state,      // permutation state
-    const uint8_t* const __restrict data,  // N (>0) -bytes associated data
-    const size_t d_len                     // len(data) = N -bytes | N > 0
-) {
-  constexpr size_t RATE_W = RATE >> 2;  // # -of 32 -bit words
+template<const size_t RATE,
+         const size_t CAPACITY,
+         const uint32_t CONST_A0,
+         const uint32_t CONST_A1,
+         const size_t nb,
+         const size_t ns_slim,
+         const size_t ns_big>
+static inline void
+process_data(
+  uint32_t* const __restrict state,     // permutation state
+  const uint8_t* const __restrict data, // N (>0) -bytes associated data
+  const size_t d_len                    // len(data) = N -bytes | N > 0
+)
+{
+  constexpr size_t RATE_W = RATE >> 2; // # -of 32 -bit words
 
   uint32_t buffer0[RATE_W ^ 1];
   uint32_t buffer1[RATE_W];
@@ -300,12 +320,12 @@ static inline void process_data(
     word |= static_cast<uint32_t>(data[b_off + off + i]) << (i << 3);
   }
 
-  const uint32_t words[2] = {0u, word};
+  const uint32_t words[2] = { 0u, word };
   buffer0[rb_full_words] = words[rb_full_words < RATE_W];
 
   rho1<RATE>(state, buffer0);
 
-  constexpr uint32_t consts[2] = {CONST_A1, CONST_A0};
+  constexpr uint32_t consts[2] = { CONST_A1, CONST_A0 };
   state[(nb << 1) - 1] ^= consts[rb_full_words < RATE_W];
 
   if constexpr (((RATE ^ 32ul) | (CAPACITY ^ 16ul)) == 0) {
@@ -337,16 +357,21 @@ static inline void process_data(
 // state, while producing equal many cipher text bytes, using algorithm 2.{13,
 // 15, 17, 19} of Sparkle specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-template <const size_t RATE, const size_t CAPACITY, const uint32_t CONST_M0,
-          const uint32_t CONST_M1, const size_t nb, const size_t ns_slim,
-          const size_t ns_big>
-static inline void process_text(
-    uint32_t* const __restrict state,     // permutation state
-    const uint8_t* const __restrict txt,  // N (>0) -bytes plain text
-    uint8_t* const __restrict enc,        // N (>0) -bytes encrypted text
-    const size_t ct_len                   // len(txt) = len(enc) = N | N > 0
-) {
-  constexpr size_t RATE_W = RATE >> 2;  // # -of 32 -bit words
+template<const size_t RATE,
+         const size_t CAPACITY,
+         const uint32_t CONST_M0,
+         const uint32_t CONST_M1,
+         const size_t nb,
+         const size_t ns_slim,
+         const size_t ns_big>
+static inline void
+process_text(uint32_t* const __restrict state,    // permutation state
+             const uint8_t* const __restrict txt, // N (>0) -bytes plain text
+             uint8_t* const __restrict enc, // N (>0) -bytes encrypted text
+             const size_t ct_len            // len(txt) = len(enc) = N | N > 0
+)
+{
+  constexpr size_t RATE_W = RATE >> 2; // # -of 32 -bit words
 
   uint32_t buffer0[RATE_W + 1];
   uint32_t buffer1[RATE_W];
@@ -451,7 +476,7 @@ static inline void process_text(
     word |= static_cast<uint32_t>(txt[idx]) << (i << 3);
   }
 
-  const uint32_t words[2] = {0u, word};
+  const uint32_t words[2] = { 0u, word };
   buffer0[rb_full_words] = words[rb_full_words < RATE_W];
 
   std::memcpy(buffer2, state, RATE);
@@ -478,7 +503,7 @@ static inline void process_text(
 
   rho1<RATE>(state, buffer0);
 
-  constexpr uint32_t consts[2] = {CONST_M1, CONST_M0};
+  constexpr uint32_t consts[2] = { CONST_M1, CONST_M0 };
   state[(nb << 1) - 1] ^= consts[rb_full_words < RATE_W];
 
   if constexpr (((RATE ^ 32ul) | (CAPACITY ^ 16ul)) == 0) {
@@ -510,16 +535,22 @@ static inline void process_text(
 // into permutation state, while producing equal many decrypted text bytes,
 // using algorithm 2.{14, 16, 18, 20} of Sparkle specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-template <const size_t RATE, const size_t CAPACITY, const uint32_t CONST_M0,
-          const uint32_t CONST_M1, const size_t nb, const size_t ns_slim,
-          const size_t ns_big>
-static inline void process_cipher(
-    uint32_t* const __restrict state,     // permutation state
-    const uint8_t* const __restrict enc,  // N (>0) -bytes encrypted text
-    uint8_t* const __restrict dec,        // N (>0) -bytes decrypted text
-    const size_t ct_len                   // len(enc) = len(dec) = N | N > 0
-) {
-  constexpr size_t RATE_W = RATE >> 2;  // # -of 32 -bit words
+template<const size_t RATE,
+         const size_t CAPACITY,
+         const uint32_t CONST_M0,
+         const uint32_t CONST_M1,
+         const size_t nb,
+         const size_t ns_slim,
+         const size_t ns_big>
+static inline void
+process_cipher(
+  uint32_t* const __restrict state,    // permutation state
+  const uint8_t* const __restrict enc, // N (>0) -bytes encrypted text
+  uint8_t* const __restrict dec,       // N (>0) -bytes decrypted text
+  const size_t ct_len                  // len(enc) = len(dec) = N | N > 0
+)
+{
+  constexpr size_t RATE_W = RATE >> 2; // # -of 32 -bit words
 
   uint32_t buffer0[RATE_W + 1];
   uint32_t buffer1[RATE_W];
@@ -624,7 +655,7 @@ static inline void process_cipher(
     word |= static_cast<uint32_t>(enc[idx]) << (i << 3);
   }
 
-  const uint32_t words[2] = {0u, word};
+  const uint32_t words[2] = { 0u, word };
   buffer0[rb_full_words] = words[rb_full_words < RATE_W];
 
   std::memcpy(buffer2, state, RATE);
@@ -667,7 +698,7 @@ static inline void process_cipher(
     rhoprime1<RATE>(state, buffer0);
   }
 
-  constexpr uint32_t consts[2] = {CONST_M1, CONST_M0};
+  constexpr uint32_t consts[2] = { CONST_M1, CONST_M0 };
   state[(nb << 1) - 1] ^= consts[rb_full_words < RATE_W];
 
   if constexpr (((RATE ^ 32ul) | (CAPACITY ^ 16ul)) == 0) {
@@ -700,14 +731,15 @@ static inline void process_cipher(
 //
 // See algorithm 2.13 of Sparkle specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-template <const size_t RATE, const size_t CAPACITY>
-static inline void finalize(
-    const uint32_t* const __restrict state,  // permutation state
-    const uint8_t* const __restrict key,     // CAPACITY -bytes secret key
-    uint8_t* const __restrict tag            // CAPACITY -bytes tag
-) {
-  constexpr size_t RATE_W = RATE >> 2;          // # -of 32 -bit words
-  constexpr size_t CAPACITY_W = CAPACITY >> 2;  // # -of 32 -bit words
+template<const size_t RATE, const size_t CAPACITY>
+static inline void
+finalize(const uint32_t* const __restrict state, // permutation state
+         const uint8_t* const __restrict key,    // CAPACITY -bytes secret key
+         uint8_t* const __restrict tag           // CAPACITY -bytes tag
+)
+{
+  constexpr size_t RATE_W = RATE >> 2;         // # -of 32 -bit words
+  constexpr size_t CAPACITY_W = CAPACITY >> 2; // # -of 32 -bit words
 
   uint32_t buffer[CAPACITY_W];
 
@@ -768,19 +800,26 @@ static inline void finalize(
 // v)   BR = # -of branches in permutation state | = ((R + C) >> 2) >> 1
 // vi)  S = # -of steps in slim variant of Sparkle permutation
 // vii) B = # -of steps in big variant of Sparkle permutation
-template <const size_t R, const size_t C, const uint32_t A0, const uint32_t A1,
-          const uint32_t M0, const uint32_t M1, const size_t BR, const size_t S,
-          const size_t B>
-static inline void encrypt(
-    const uint8_t* const __restrict key,    // C -bytes secret key
-    const uint8_t* const __restrict nonce,  // R -bytes nonce
-    const uint8_t* const __restrict data,   // N (>=0) -bytes associated data
-    const size_t d_len,                     // len(data) = N | N >= 0
-    const uint8_t* const __restrict txt,    // N (>=0) -bytes plain text
-    uint8_t* const __restrict enc,          // N (>=0) -bytes cipher text
-    const size_t ct_len,                    // len(txt) = len(enc) = N | >= 0
-    uint8_t* const __restrict tag           // C -bytes authentication tag
-) {
+template<const size_t R,
+         const size_t C,
+         const uint32_t A0,
+         const uint32_t A1,
+         const uint32_t M0,
+         const uint32_t M1,
+         const size_t BR,
+         const size_t S,
+         const size_t B>
+static inline void
+encrypt(const uint8_t* const __restrict key,   // C -bytes secret key
+        const uint8_t* const __restrict nonce, // R -bytes nonce
+        const uint8_t* const __restrict data,  // N (>=0) -bytes associated data
+        const size_t d_len,                    // len(data) = N | N >= 0
+        const uint8_t* const __restrict txt,   // N (>=0) -bytes plain text
+        uint8_t* const __restrict enc,         // N (>=0) -bytes cipher text
+        const size_t ct_len,                   // len(txt) = len(enc) = N | >= 0
+        uint8_t* const __restrict tag          // C -bytes authentication tag
+)
+{
   uint32_t state[BR << 1];
 
   initialize<R, C, BR, B>(state, key, nonce);
@@ -805,19 +844,26 @@ static inline void encrypt(
 // v)   BR = # -of branches in permutation state | = ((R + C) >> 2) >> 1
 // vi)  S = # -of steps in slim variant of Sparkle permutation
 // vii) B = # -of steps in big variant of Sparkle permutation
-template <const size_t R, const size_t C, const uint32_t A0, const uint32_t A1,
-          const uint32_t M0, const uint32_t M1, const size_t BR, const size_t S,
-          const size_t B>
-static inline bool decrypt(
-    const uint8_t* const __restrict key,    // C -bytes secret key
-    const uint8_t* const __restrict nonce,  // R -bytes nonce
-    const uint8_t* const __restrict tag,    // C -bytes authentication tag
-    const uint8_t* const __restrict data,   // N (>=0) -bytes associated data
-    const size_t d_len,                     // len(data) = N | N >= 0
-    const uint8_t* const __restrict enc,    // N (>=0) -bytes encrypted text
-    uint8_t* const __restrict dec,          // N (>=0) -bytes decrypted text
-    const size_t ct_len                     // len(enc) = len(dec) = N | >= 0
-) {
+template<const size_t R,
+         const size_t C,
+         const uint32_t A0,
+         const uint32_t A1,
+         const uint32_t M0,
+         const uint32_t M1,
+         const size_t BR,
+         const size_t S,
+         const size_t B>
+static inline bool
+decrypt(const uint8_t* const __restrict key,   // C -bytes secret key
+        const uint8_t* const __restrict nonce, // R -bytes nonce
+        const uint8_t* const __restrict tag,   // C -bytes authentication tag
+        const uint8_t* const __restrict data,  // N (>=0) -bytes associated data
+        const size_t d_len,                    // len(data) = N | N >= 0
+        const uint8_t* const __restrict enc,   // N (>=0) -bytes encrypted text
+        uint8_t* const __restrict dec,         // N (>=0) -bytes decrypted text
+        const size_t ct_len                    // len(enc) = len(dec) = N | >= 0
+)
+{
   uint32_t state[BR << 1];
   uint8_t tag_[C];
 
@@ -839,4 +885,4 @@ static inline bool decrypt(
   return !flag;
 }
 
-}  // namespace aead
+} // namespace aead

--- a/include/bench/bench_aead.hpp
+++ b/include/bench/bench_aead.hpp
@@ -10,7 +10,9 @@
 #include "utils.hpp"
 
 // Benchmark Schwaemm256-128 Authenticated Encryption Scheme on CPU
-void schwaemm256_128_encrypt(benchmark::State& state) {
+void
+schwaemm256_128_encrypt(benchmark::State& state)
+{
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -62,7 +64,9 @@ void schwaemm256_128_encrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm256-128 Verified Decryption Scheme on CPU
-void schwaemm256_128_decrypt(benchmark::State& state) {
+void
+schwaemm256_128_decrypt(benchmark::State& state)
+{
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -124,7 +128,9 @@ void schwaemm256_128_decrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm192-192 Authenticated Encryption Scheme on CPU
-void schwaemm192_192_encrypt(benchmark::State& state) {
+void
+schwaemm192_192_encrypt(benchmark::State& state)
+{
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -178,7 +184,9 @@ void schwaemm192_192_encrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm192-192 Verified Decryption Scheme on CPU
-void schwaemm192_192_decrypt(benchmark::State& state) {
+void
+schwaemm192_192_decrypt(benchmark::State& state)
+{
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -242,7 +250,9 @@ void schwaemm192_192_decrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm128-128 Authenticated Encryption Scheme on CPU
-void schwaemm128_128_encrypt(benchmark::State& state) {
+void
+schwaemm128_128_encrypt(benchmark::State& state)
+{
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -296,7 +306,9 @@ void schwaemm128_128_encrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm128-128 Verified Decryption Scheme on CPU
-void schwaemm128_128_decrypt(benchmark::State& state) {
+void
+schwaemm128_128_decrypt(benchmark::State& state)
+{
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -360,7 +372,9 @@ void schwaemm128_128_decrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm256-256 Authenticated Encryption Scheme on CPU
-void schwaemm256_256_encrypt(benchmark::State& state) {
+void
+schwaemm256_256_encrypt(benchmark::State& state)
+{
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -414,7 +428,9 @@ void schwaemm256_256_encrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm256-256 Verified Decryption Scheme on CPU
-void schwaemm256_256_decrypt(benchmark::State& state) {
+void
+schwaemm256_256_decrypt(benchmark::State& state)
+{
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 

--- a/include/bench/bench_aead.hpp
+++ b/include/bench/bench_aead.hpp
@@ -1,13 +1,8 @@
 #pragma once
-#include <benchmark/benchmark.h>
-
-#include <cassert>
-
-#include "schwaemm128_128.hpp"
-#include "schwaemm192_192.hpp"
-#include "schwaemm256_128.hpp"
-#include "schwaemm256_256.hpp"
+#include "schwaemm.hpp"
 #include "utils.hpp"
+#include <benchmark/benchmark.h>
+#include <cassert>
 
 // Benchmark Schwaemm256-128 Authenticated Encryption Scheme on CPU
 void

--- a/include/bench/bench_aead.hpp
+++ b/include/bench/bench_aead.hpp
@@ -25,13 +25,13 @@ schwaemm256_128_encrypt(benchmark::State& state)
   uint8_t* tag = static_cast<uint8_t*>(malloc(schwaemm256_128::C));
 
   // random plain text bytes
-  random_data(text, ct_len);
+  sparkle_utils::random_data(text, ct_len);
   // random associated data bytes
-  random_data(data, dt_len);
+  sparkle_utils::random_data(data, dt_len);
   // random secret key ( = 128 -bit )
-  random_data(key, schwaemm256_128::C);
+  sparkle_utils::random_data(key, schwaemm256_128::C);
   // random public message nonce ( = 256 -bit )
-  random_data(nonce, schwaemm256_128::R);
+  sparkle_utils::random_data(nonce, schwaemm256_128::R);
 
   memset(enc, 0, ct_len);
   memset(tag, 0, schwaemm256_128::C);
@@ -80,13 +80,13 @@ schwaemm256_128_decrypt(benchmark::State& state)
   uint8_t* tag = static_cast<uint8_t*>(malloc(schwaemm256_128::C));
 
   // random plain text bytes
-  random_data(text, ct_len);
+  sparkle_utils::random_data(text, ct_len);
   // random associated data bytes
-  random_data(data, dt_len);
+  sparkle_utils::random_data(data, dt_len);
   // random secret key ( = 128 -bit )
-  random_data(key, schwaemm256_128::C);
+  sparkle_utils::random_data(key, schwaemm256_128::C);
   // random public message nonce ( = 256 -bit )
-  random_data(nonce, schwaemm256_128::R);
+  sparkle_utils::random_data(nonce, schwaemm256_128::R);
 
   memset(enc, 0, ct_len);
   memset(dec, 0, ct_len);
@@ -145,13 +145,13 @@ schwaemm192_192_encrypt(benchmark::State& state)
   uint8_t* tag = static_cast<uint8_t*>(malloc(KNT_LEN));
 
   // random plain text bytes
-  random_data(text, ct_len);
+  sparkle_utils::random_data(text, ct_len);
   // random associated data bytes
-  random_data(data, dt_len);
+  sparkle_utils::random_data(data, dt_len);
   // random secret key ( = 192 -bit )
-  random_data(key, KNT_LEN);
+  sparkle_utils::random_data(key, KNT_LEN);
   // random public message nonce ( = 192 -bit )
-  random_data(nonce, KNT_LEN);
+  sparkle_utils::random_data(nonce, KNT_LEN);
 
   memset(enc, 0, ct_len);
   memset(tag, 0, KNT_LEN);
@@ -202,13 +202,13 @@ schwaemm192_192_decrypt(benchmark::State& state)
   uint8_t* tag = static_cast<uint8_t*>(malloc(KNT_LEN));
 
   // random plain text bytes
-  random_data(text, ct_len);
+  sparkle_utils::random_data(text, ct_len);
   // random associated data bytes
-  random_data(data, dt_len);
+  sparkle_utils::random_data(data, dt_len);
   // random secret key ( = 192 -bit )
-  random_data(key, KNT_LEN);
+  sparkle_utils::random_data(key, KNT_LEN);
   // random public message nonce ( = 192 -bit )
-  random_data(nonce, KNT_LEN);
+  sparkle_utils::random_data(nonce, KNT_LEN);
 
   memset(enc, 0, ct_len);
   memset(dec, 0, ct_len);
@@ -267,13 +267,13 @@ schwaemm128_128_encrypt(benchmark::State& state)
   uint8_t* tag = static_cast<uint8_t*>(malloc(KNT_LEN));
 
   // random plain text bytes
-  random_data(text, ct_len);
+  sparkle_utils::random_data(text, ct_len);
   // random associated data bytes
-  random_data(data, dt_len);
+  sparkle_utils::random_data(data, dt_len);
   // random secret key ( = 128 -bit )
-  random_data(key, KNT_LEN);
+  sparkle_utils::random_data(key, KNT_LEN);
   // random public message nonce ( = 128 -bit )
-  random_data(nonce, KNT_LEN);
+  sparkle_utils::random_data(nonce, KNT_LEN);
 
   memset(enc, 0, ct_len);
   memset(tag, 0, KNT_LEN);
@@ -324,13 +324,13 @@ schwaemm128_128_decrypt(benchmark::State& state)
   uint8_t* tag = static_cast<uint8_t*>(malloc(KNT_LEN));
 
   // random plain text bytes
-  random_data(text, ct_len);
+  sparkle_utils::random_data(text, ct_len);
   // random associated data bytes
-  random_data(data, dt_len);
+  sparkle_utils::random_data(data, dt_len);
   // random secret key ( = 128 -bit )
-  random_data(key, KNT_LEN);
+  sparkle_utils::random_data(key, KNT_LEN);
   // random public message nonce ( = 128 -bit )
-  random_data(nonce, KNT_LEN);
+  sparkle_utils::random_data(nonce, KNT_LEN);
 
   memset(enc, 0, ct_len);
   memset(dec, 0, ct_len);
@@ -389,13 +389,13 @@ schwaemm256_256_encrypt(benchmark::State& state)
   uint8_t* tag = static_cast<uint8_t*>(malloc(KNT_LEN));
 
   // random plain text bytes
-  random_data(text, ct_len);
+  sparkle_utils::random_data(text, ct_len);
   // random associated data bytes
-  random_data(data, dt_len);
+  sparkle_utils::random_data(data, dt_len);
   // random secret key ( = 256 -bit )
-  random_data(key, KNT_LEN);
+  sparkle_utils::random_data(key, KNT_LEN);
   // random public message nonce ( = 256 -bit )
-  random_data(nonce, KNT_LEN);
+  sparkle_utils::random_data(nonce, KNT_LEN);
 
   memset(enc, 0, ct_len);
   memset(tag, 0, KNT_LEN);
@@ -446,13 +446,13 @@ schwaemm256_256_decrypt(benchmark::State& state)
   uint8_t* tag = static_cast<uint8_t*>(malloc(KNT_LEN));
 
   // random plain text bytes
-  random_data(text, ct_len);
+  sparkle_utils::random_data(text, ct_len);
   // random associated data bytes
-  random_data(data, dt_len);
+  sparkle_utils::random_data(data, dt_len);
   // random secret key ( = 256 -bit )
-  random_data(key, KNT_LEN);
+  sparkle_utils::random_data(key, KNT_LEN);
   // random public message nonce ( = 256 -bit )
-  random_data(nonce, KNT_LEN);
+  sparkle_utils::random_data(nonce, KNT_LEN);
 
   memset(enc, 0, ct_len);
   memset(dec, 0, ct_len);

--- a/include/bench/bench_aead.hpp
+++ b/include/bench/bench_aead.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <benchmark/benchmark.h>
 
+#include <cassert>
+
 #include "schwaemm128_128.hpp"
 #include "schwaemm192_192.hpp"
 #include "schwaemm256_128.hpp"
@@ -8,7 +10,7 @@
 #include "utils.hpp"
 
 // Benchmark Schwaemm256-128 Authenticated Encryption Scheme on CPU
-static void schwaemm256_128_encrypt(benchmark::State& state) {
+void schwaemm256_128_encrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -35,7 +37,13 @@ static void schwaemm256_128_encrypt(benchmark::State& state) {
   for (auto _ : state) {
     schwaemm256_128::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
 
+    benchmark::DoNotOptimize(key);
+    benchmark::DoNotOptimize(nonce);
+    benchmark::DoNotOptimize(data);
+    benchmark::DoNotOptimize(dt_len);
+    benchmark::DoNotOptimize(text);
     benchmark::DoNotOptimize(enc);
+    benchmark::DoNotOptimize(ct_len);
     benchmark::DoNotOptimize(tag);
   }
 
@@ -54,7 +62,7 @@ static void schwaemm256_128_encrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm256-128 Verified Decryption Scheme on CPU
-static void schwaemm256_128_decrypt(benchmark::State& state) {
+void schwaemm256_128_decrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -86,8 +94,18 @@ static void schwaemm256_128_decrypt(benchmark::State& state) {
     using namespace schwaemm256_128;
     using namespace benchmark;
 
-    DoNotOptimize(decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len));
+    bool flg = decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len);
+
+    DoNotOptimize(flg);
+    assert(flg);
+    DoNotOptimize(key);
+    DoNotOptimize(nonce);
+    DoNotOptimize(tag);
+    DoNotOptimize(data);
+    DoNotOptimize(dt_len);
+    DoNotOptimize(enc);
     DoNotOptimize(dec);
+    DoNotOptimize(ct_len);
   }
 
   const size_t per_itr_data = dt_len + ct_len;
@@ -106,7 +124,7 @@ static void schwaemm256_128_decrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm192-192 Authenticated Encryption Scheme on CPU
-static void schwaemm192_192_encrypt(benchmark::State& state) {
+void schwaemm192_192_encrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -135,7 +153,13 @@ static void schwaemm192_192_encrypt(benchmark::State& state) {
   for (auto _ : state) {
     schwaemm192_192::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
 
+    benchmark::DoNotOptimize(key);
+    benchmark::DoNotOptimize(nonce);
+    benchmark::DoNotOptimize(data);
+    benchmark::DoNotOptimize(dt_len);
+    benchmark::DoNotOptimize(text);
     benchmark::DoNotOptimize(enc);
+    benchmark::DoNotOptimize(ct_len);
     benchmark::DoNotOptimize(tag);
   }
 
@@ -154,7 +178,7 @@ static void schwaemm192_192_encrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm192-192 Verified Decryption Scheme on CPU
-static void schwaemm192_192_decrypt(benchmark::State& state) {
+void schwaemm192_192_decrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -188,8 +212,18 @@ static void schwaemm192_192_decrypt(benchmark::State& state) {
     using namespace schwaemm192_192;
     using namespace benchmark;
 
-    DoNotOptimize(decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len));
+    bool flg = decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len);
+
+    DoNotOptimize(flg);
+    assert(flg);
+    DoNotOptimize(key);
+    DoNotOptimize(nonce);
+    DoNotOptimize(tag);
+    DoNotOptimize(data);
+    DoNotOptimize(dt_len);
+    DoNotOptimize(enc);
     DoNotOptimize(dec);
+    DoNotOptimize(ct_len);
   }
 
   const size_t per_itr_data = dt_len + ct_len;
@@ -208,7 +242,7 @@ static void schwaemm192_192_decrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm128-128 Authenticated Encryption Scheme on CPU
-static void schwaemm128_128_encrypt(benchmark::State& state) {
+void schwaemm128_128_encrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -237,7 +271,13 @@ static void schwaemm128_128_encrypt(benchmark::State& state) {
   for (auto _ : state) {
     schwaemm128_128::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
 
+    benchmark::DoNotOptimize(key);
+    benchmark::DoNotOptimize(nonce);
+    benchmark::DoNotOptimize(data);
+    benchmark::DoNotOptimize(dt_len);
+    benchmark::DoNotOptimize(text);
     benchmark::DoNotOptimize(enc);
+    benchmark::DoNotOptimize(ct_len);
     benchmark::DoNotOptimize(tag);
   }
 
@@ -256,7 +296,7 @@ static void schwaemm128_128_encrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm128-128 Verified Decryption Scheme on CPU
-static void schwaemm128_128_decrypt(benchmark::State& state) {
+void schwaemm128_128_decrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -290,8 +330,18 @@ static void schwaemm128_128_decrypt(benchmark::State& state) {
     using namespace schwaemm128_128;
     using namespace benchmark;
 
-    DoNotOptimize(decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len));
+    bool flg = decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len);
+
+    DoNotOptimize(flg);
+    assert(flg);
+    DoNotOptimize(key);
+    DoNotOptimize(nonce);
+    DoNotOptimize(tag);
+    DoNotOptimize(data);
+    DoNotOptimize(dt_len);
+    DoNotOptimize(enc);
     DoNotOptimize(dec);
+    DoNotOptimize(ct_len);
   }
 
   const size_t per_itr_data = dt_len + ct_len;
@@ -310,7 +360,7 @@ static void schwaemm128_128_decrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm256-256 Authenticated Encryption Scheme on CPU
-static void schwaemm256_256_encrypt(benchmark::State& state) {
+void schwaemm256_256_encrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -339,7 +389,13 @@ static void schwaemm256_256_encrypt(benchmark::State& state) {
   for (auto _ : state) {
     schwaemm256_256::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
 
+    benchmark::DoNotOptimize(key);
+    benchmark::DoNotOptimize(nonce);
+    benchmark::DoNotOptimize(data);
+    benchmark::DoNotOptimize(dt_len);
+    benchmark::DoNotOptimize(text);
     benchmark::DoNotOptimize(enc);
+    benchmark::DoNotOptimize(ct_len);
     benchmark::DoNotOptimize(tag);
   }
 
@@ -358,7 +414,7 @@ static void schwaemm256_256_encrypt(benchmark::State& state) {
 }
 
 // Benchmark Schwaemm256-256 Verified Decryption Scheme on CPU
-static void schwaemm256_256_decrypt(benchmark::State& state) {
+void schwaemm256_256_decrypt(benchmark::State& state) {
   const size_t ct_len = state.range(0);
   const size_t dt_len = state.range(1);
 
@@ -392,8 +448,18 @@ static void schwaemm256_256_decrypt(benchmark::State& state) {
     using namespace schwaemm256_256;
     using namespace benchmark;
 
-    DoNotOptimize(decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len));
+    bool flg = decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len);
+
+    DoNotOptimize(flg);
+    assert(flg);
+    DoNotOptimize(key);
+    DoNotOptimize(nonce);
+    DoNotOptimize(tag);
+    DoNotOptimize(data);
+    DoNotOptimize(dt_len);
+    DoNotOptimize(enc);
     DoNotOptimize(dec);
+    DoNotOptimize(ct_len);
   }
 
   const size_t per_itr_data = dt_len + ct_len;

--- a/include/bench/bench_hash.hpp
+++ b/include/bench/bench_hash.hpp
@@ -16,7 +16,7 @@ esch256_hash(benchmark::State& state)
   uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* out = static_cast<uint8_t*>(std::malloc(dlen));
 
-  random_data(msg, mlen);
+  sparkle_utils::random_data(msg, mlen);
   std::memset(out, 0, dlen);
 
   for (auto _ : state) {
@@ -45,7 +45,7 @@ esch384_hash(benchmark::State& state)
   uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* out = static_cast<uint8_t*>(std::malloc(dlen));
 
-  random_data(msg, mlen);
+  sparkle_utils::random_data(msg, mlen);
   std::memset(out, 0, dlen);
 
   for (auto _ : state) {

--- a/include/bench/bench_hash.hpp
+++ b/include/bench/bench_hash.hpp
@@ -7,9 +7,9 @@
 
 // Benchmarks Esch256 cryptographic hash function implementation for random
 // input of length N (>=0) -bytes | N is provided when setting up benchmark
-static void esch256_hash(benchmark::State& state) {
+void esch256_hash(benchmark::State& state) {
   const size_t mlen = static_cast<size_t>(state.range(0));
-  const size_t dlen = 32ul;
+  const size_t dlen = esch256::DIGEST_LEN;
 
   uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* out = static_cast<uint8_t*>(std::malloc(dlen));
@@ -20,6 +20,8 @@ static void esch256_hash(benchmark::State& state) {
   for (auto _ : state) {
     esch256::hash(msg, mlen, out);
 
+    benchmark::DoNotOptimize(msg);
+    benchmark::DoNotOptimize(mlen);
     benchmark::DoNotOptimize(out);
     benchmark::ClobberMemory();
   }
@@ -32,9 +34,9 @@ static void esch256_hash(benchmark::State& state) {
 
 // Benchmarks Esch384 cryptographic hash function implementation for random
 // input of length N (>=0) -bytes | N is provided when setting up benchmark
-static void esch384_hash(benchmark::State& state) {
+void esch384_hash(benchmark::State& state) {
   const size_t mlen = static_cast<size_t>(state.range(0));
-  const size_t dlen = 48ul;
+  const size_t dlen = esch384::DIGEST_LEN;
 
   uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* out = static_cast<uint8_t*>(std::malloc(dlen));
@@ -45,6 +47,8 @@ static void esch384_hash(benchmark::State& state) {
   for (auto _ : state) {
     esch384::hash(msg, mlen, out);
 
+    benchmark::DoNotOptimize(msg);
+    benchmark::DoNotOptimize(mlen);
     benchmark::DoNotOptimize(out);
     benchmark::ClobberMemory();
   }

--- a/include/bench/bench_hash.hpp
+++ b/include/bench/bench_hash.hpp
@@ -7,7 +7,9 @@
 
 // Benchmarks Esch256 cryptographic hash function implementation for random
 // input of length N (>=0) -bytes | N is provided when setting up benchmark
-void esch256_hash(benchmark::State& state) {
+void
+esch256_hash(benchmark::State& state)
+{
   const size_t mlen = static_cast<size_t>(state.range(0));
   const size_t dlen = esch256::DIGEST_LEN;
 
@@ -34,7 +36,9 @@ void esch256_hash(benchmark::State& state) {
 
 // Benchmarks Esch384 cryptographic hash function implementation for random
 // input of length N (>=0) -bytes | N is provided when setting up benchmark
-void esch384_hash(benchmark::State& state) {
+void
+esch384_hash(benchmark::State& state)
+{
   const size_t mlen = static_cast<size_t>(state.range(0));
   const size_t dlen = esch384::DIGEST_LEN;
 

--- a/include/bench/bench_hash.hpp
+++ b/include/bench/bench_hash.hpp
@@ -1,9 +1,7 @@
 #pragma once
-#include <benchmark/benchmark.h>
-
-#include "esch256.hpp"
-#include "esch384.hpp"
+#include "esch.hpp"
 #include "utils.hpp"
+#include <benchmark/benchmark.h>
 
 // Benchmarks Esch256 cryptographic hash function implementation for random
 // input of length N (>=0) -bytes | N is provided when setting up benchmark

--- a/include/bench/bench_permutation.hpp
+++ b/include/bench/bench_permutation.hpp
@@ -1,8 +1,7 @@
 #pragma once
-#include <benchmark/benchmark.h>
-
 #include "sparkle.hpp"
 #include "utils.hpp"
+#include <benchmark/benchmark.h>
 
 // Benchmark Sparkle Cipher Suite on CPU
 namespace bench_sparkle {

--- a/include/bench/bench_permutation.hpp
+++ b/include/bench/bench_permutation.hpp
@@ -8,8 +8,10 @@
 namespace bench_sparkle {
 
 // Benchmark slim/ big variant of Sparkle{256, 384, 512} permutation
-template <const size_t nb, const size_t ns>
-void sparkle(benchmark::State& state) {
+template<const size_t nb, const size_t ns>
+void
+sparkle(benchmark::State& state)
+{
   uint32_t st[2 * nb];
   random_data(st, 2 * nb);
 
@@ -22,4 +24,4 @@ void sparkle(benchmark::State& state) {
   state.SetBytesProcessed(total_bytes);
 }
 
-}  // namespace bench_sparkle
+} // namespace bench_sparkle

--- a/include/bench/bench_permutation.hpp
+++ b/include/bench/bench_permutation.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <benchmark/benchmark.h>
+
+#include "sparkle.hpp"
+#include "utils.hpp"
+
+// Benchmark Sparkle Cipher Suite on CPU
+namespace bench_sparkle {
+
+// Benchmark slim/ big variant of Sparkle{256, 384, 512} permutation
+template <const size_t nb, const size_t ns>
+void sparkle(benchmark::State& state) {
+  uint32_t st[2 * nb];
+  random_data(st, 2 * nb);
+
+  for (auto _ : state) {
+    sparkle::sparkle<nb, ns>(st);
+    benchmark::DoNotOptimize(st);
+  }
+
+  const size_t total_bytes = sizeof(st) * state.iterations();
+  state.SetBytesProcessed(total_bytes);
+}
+
+}  // namespace bench_sparkle

--- a/include/bench/bench_permutation.hpp
+++ b/include/bench/bench_permutation.hpp
@@ -13,7 +13,7 @@ void
 sparkle(benchmark::State& state)
 {
   uint32_t st[2 * nb];
-  random_data(st, 2 * nb);
+  sparkle_utils::random_data(st, 2 * nb);
 
   for (auto _ : state) {
     sparkle::sparkle<nb, ns>(st);

--- a/include/bench/bench_sparkle.hpp
+++ b/include/bench/bench_sparkle.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "bench_aead.hpp"
+#include "bench_hash.hpp"

--- a/include/bench/bench_sparkle.hpp
+++ b/include/bench/bench_sparkle.hpp
@@ -2,3 +2,4 @@
 
 #include "bench_aead.hpp"
 #include "bench_hash.hpp"
+#include "bench_permutation.hpp"

--- a/include/esch.hpp
+++ b/include/esch.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "esch256.hpp"
+#include "esch384.hpp"

--- a/include/esch256.hpp
+++ b/include/esch256.hpp
@@ -44,17 +44,18 @@ hash(const uint8_t* const __restrict in, // input message
     rm_bytes -= hash::RATE;
   }
 
-  const size_t b_off = ilen - rm_bytes;
+  size_t b_off = ilen - rm_bytes;
+
   const size_t rb_full_words = rm_bytes >> 2;
   const size_t rb_full_bytes = rb_full_words << 2;
   const size_t rb_rem_bytes = rm_bytes & 3ul;
-  const size_t off = b_off + rb_full_bytes;
 
   std::memset(buffer, 0, hash::RATE);
   sparkle_utils::copy_le_bytes_to_words(in + b_off, buffer, rb_full_bytes);
+  b_off += rb_full_bytes;
 
   uint32_t word = 0x80u << (rb_rem_bytes << 3);
-  sparkle_utils::copy_le_bytes_to_words(in + off, &word, rb_rem_bytes);
+  sparkle_utils::copy_le_bytes_to_words(in + b_off, &word, rb_rem_bytes);
 
   const uint32_t words[]{ 0u, word };
   buffer[rb_full_words] = words[rb_full_words < 4];

--- a/include/esch256.hpp
+++ b/include/esch256.hpp
@@ -26,42 +26,48 @@ static inline void hash(
     const size_t ilen,                   // len(in) = N | N >= 0
     uint8_t* const __restrict out        // 32 -bytes output digest
 ) {
-  uint32_t state[12] = {0u};
-  uint32_t buffer[6] = {0u};
+  uint32_t state[12]{};
+  uint32_t buffer[6]{};
 
-  size_t r_bytes = ilen;
-  while (r_bytes > hash::RATE) {
-    const size_t b_off = ilen - r_bytes;
-
-    std::memset(buffer + 4, 0, 8);
+  size_t rm_bytes = ilen;
+  while (rm_bytes > hash::RATE) {
+    const size_t b_off = ilen - rm_bytes;
 
     if constexpr (is_little_endian()) {
       std::memcpy(buffer, in + b_off, hash::RATE);
     } else {
 #if defined __clang__
-#pragma unroll 4
+      // Following
+      // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
 #elif defined __GNUG__
+      // Following
+      // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
 #pragma GCC unroll 4
 #endif
       for (size_t j = 0; j < 4; j++) {
         const size_t i_off = j << 2;
 
-        buffer[j] = (static_cast<uint32_t>(in[b_off + (i_off ^ 3)]) << 24) |
-                    (static_cast<uint32_t>(in[b_off + (i_off ^ 2)]) << 16) |
-                    (static_cast<uint32_t>(in[b_off + (i_off ^ 1)]) << 8) |
-                    (static_cast<uint32_t>(in[b_off + (i_off ^ 0)]) << 0);
+        buffer[j] = (static_cast<uint32_t>(in[b_off + (i_off + 3)]) << 24) |
+                    (static_cast<uint32_t>(in[b_off + (i_off + 2)]) << 16) |
+                    (static_cast<uint32_t>(in[b_off + (i_off + 1)]) << 8) |
+                    (static_cast<uint32_t>(in[b_off + (i_off + 0)]) << 0);
       }
     }
 
     hash::feistel<384ul>(state, buffer);
     sparkle::sparkle<6ul, 7ul>(state);
 
-    r_bytes -= hash::RATE;
+    rm_bytes -= hash::RATE;
   }
 
-  const size_t b_off = ilen - r_bytes;
-  const size_t rb_full_words = r_bytes >> 2;
-  const size_t rb_rem_bytes = r_bytes & 3ul;
+  const size_t b_off = ilen - rm_bytes;
+  const size_t rb_full_words = rm_bytes >> 2;
+  const size_t rb_rem_bytes = rm_bytes & 3ul;
 
   std::memset(buffer, 0, 24);
 
@@ -71,10 +77,10 @@ static inline void hash(
     for (size_t i = 0; i < rb_full_words; i++) {
       const size_t off = i << 2;
 
-      buffer[i] = (static_cast<uint32_t>(in[b_off + (off ^ 3)]) << 24) |
-                  (static_cast<uint32_t>(in[b_off + (off ^ 2)]) << 16) |
-                  (static_cast<uint32_t>(in[b_off + (off ^ 1)]) << 8) |
-                  (static_cast<uint32_t>(in[b_off + (off ^ 0)]) << 0);
+      buffer[i] = (static_cast<uint32_t>(in[b_off + (off + 3)]) << 24) |
+                  (static_cast<uint32_t>(in[b_off + (off + 2)]) << 16) |
+                  (static_cast<uint32_t>(in[b_off + (off + 1)]) << 8) |
+                  (static_cast<uint32_t>(in[b_off + (off + 0)]) << 0);
     }
   }
 
@@ -89,7 +95,7 @@ static inline void hash(
   buffer[rb_full_words] = words[rb_full_words < 4];
 
   constexpr uint32_t consts[2] = {hash::CONST_M1, hash::CONST_M0};
-  state[5] ^= consts[r_bytes < hash::RATE];
+  state[5] ^= consts[rm_bytes < hash::RATE];
 
   hash::feistel<384ul>(state, buffer);
   sparkle::sparkle<6ul, 11ul>(state);
@@ -98,18 +104,26 @@ static inline void hash(
     std::memcpy(out, state, hash::RATE);
   } else {
 #if defined __clang__
-#pragma unroll 4
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
 #elif defined __GNUG__
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
 #pragma GCC unroll 4
 #endif
     for (size_t i = 0; i < 4; i++) {
       const uint32_t word = state[i];
       const size_t b_off = i << 2;
 
-      out[b_off ^ 0] = static_cast<uint8_t>(word >> 0);
-      out[b_off ^ 1] = static_cast<uint8_t>(word >> 8);
-      out[b_off ^ 2] = static_cast<uint8_t>(word >> 16);
-      out[b_off ^ 3] = static_cast<uint8_t>(word >> 24);
+      out[b_off + 0] = static_cast<uint8_t>(word >> 0);
+      out[b_off + 1] = static_cast<uint8_t>(word >> 8);
+      out[b_off + 2] = static_cast<uint8_t>(word >> 16);
+      out[b_off + 3] = static_cast<uint8_t>(word >> 24);
     }
   }
 
@@ -119,18 +133,26 @@ static inline void hash(
     std::memcpy(out + hash::RATE, state, hash::RATE);
   } else {
 #if defined __clang__
-#pragma unroll 4
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
 #elif defined __GNUG__
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
 #pragma GCC unroll 4
 #endif
     for (size_t i = 0; i < 4; i++) {
       const uint32_t word = state[i];
       const size_t b_off = i << 2;
 
-      out[16ul + (b_off ^ 0)] = static_cast<uint8_t>(word >> 0);
-      out[16ul + (b_off ^ 1)] = static_cast<uint8_t>(word >> 8);
-      out[16ul + (b_off ^ 2)] = static_cast<uint8_t>(word >> 16);
-      out[16ul + (b_off ^ 3)] = static_cast<uint8_t>(word >> 24);
+      out[16ul + (b_off + 0)] = static_cast<uint8_t>(word >> 0);
+      out[16ul + (b_off + 1)] = static_cast<uint8_t>(word >> 8);
+      out[16ul + (b_off + 2)] = static_cast<uint8_t>(word >> 16);
+      out[16ul + (b_off + 3)] = static_cast<uint8_t>(word >> 24);
     }
   }
 }

--- a/include/esch256.hpp
+++ b/include/esch256.hpp
@@ -7,6 +7,9 @@
 // Esch256 hash function, based on Sparkle permutation
 namespace esch256 {
 
+// Esch256 hash function produces 32 -bytes of digest
+constexpr size_t DIGEST_LEN = 32;
+
 // Esch256 --- lightweight, cryptographically secure hash function, based on
 // Sparkle permutation, producing 32 -bytes output from N -bytes input | N >= 0
 //

--- a/include/esch256.hpp
+++ b/include/esch256.hpp
@@ -37,7 +37,7 @@ hash(const uint8_t* const __restrict in, // input message
   while (rm_bytes > hash::RATE) {
     const size_t b_off = ilen - rm_bytes;
 
-    if constexpr (is_little_endian()) {
+    if constexpr (sparkle_utils::is_little_endian()) {
       std::memcpy(buffer, in + b_off, hash::RATE);
     } else {
 #if defined __clang__
@@ -75,7 +75,7 @@ hash(const uint8_t* const __restrict in, // input message
 
   std::memset(buffer, 0, hash::RATE);
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(buffer, in + b_off, rb_full_words << 2);
   } else {
     for (size_t i = 0; i < rb_full_words; i++) {
@@ -104,7 +104,7 @@ hash(const uint8_t* const __restrict in, // input message
   hash::feistel<384ul>(state, buffer);
   sparkle::sparkle<6ul, 11ul>(state);
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(out, state, hash::RATE);
   } else {
 #if defined __clang__
@@ -133,7 +133,7 @@ hash(const uint8_t* const __restrict in, // input message
 
   sparkle::sparkle<6ul, 7ul>(state);
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(out + hash::RATE, state, hash::RATE);
   } else {
 #if defined __clang__

--- a/include/esch256.hpp
+++ b/include/esch256.hpp
@@ -24,11 +24,12 @@ constexpr size_t DIGEST_LEN = 32;
 //
 // See algorithm 2.9 of Sparkle specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline void hash(
-    const uint8_t* const __restrict in,  // input message
-    const size_t ilen,                   // len(in) = N | N >= 0
-    uint8_t* const __restrict out        // 32 -bytes output digest
-) {
+static inline void
+hash(const uint8_t* const __restrict in, // input message
+     const size_t ilen,                  // len(in) = N | N >= 0
+     uint8_t* const __restrict out       // 32 -bytes output digest
+)
+{
   uint32_t state[12]{};
   uint32_t buffer[6]{};
 
@@ -94,10 +95,10 @@ static inline void hash(
     word |= static_cast<uint32_t>(in[b_off + off + i]) << (i << 3);
   }
 
-  const uint32_t words[]{0u, word};
+  const uint32_t words[]{ 0u, word };
   buffer[rb_full_words] = words[rb_full_words < 4];
 
-  constexpr uint32_t consts[]{hash::CONST_M1, hash::CONST_M0};
+  constexpr uint32_t consts[]{ hash::CONST_M1, hash::CONST_M0 };
   state[5] ^= consts[rm_bytes < hash::RATE];
 
   hash::feistel<384ul>(state, buffer);
@@ -160,4 +161,4 @@ static inline void hash(
   }
 }
 
-}  // namespace esch256
+} // namespace esch256

--- a/include/esch256.hpp
+++ b/include/esch256.hpp
@@ -69,7 +69,7 @@ static inline void hash(
   const size_t rb_full_words = rm_bytes >> 2;
   const size_t rb_rem_bytes = rm_bytes & 3ul;
 
-  std::memset(buffer, 0, 24);
+  std::memset(buffer, 0, hash::RATE);
 
   if constexpr (is_little_endian()) {
     std::memcpy(buffer, in + b_off, rb_full_words << 2);
@@ -91,10 +91,10 @@ static inline void hash(
     word |= static_cast<uint32_t>(in[b_off + off + i]) << (i << 3);
   }
 
-  const uint32_t words[2] = {0u, word};
+  const uint32_t words[]{0u, word};
   buffer[rb_full_words] = words[rb_full_words < 4];
 
-  constexpr uint32_t consts[2] = {hash::CONST_M1, hash::CONST_M0};
+  constexpr uint32_t consts[]{hash::CONST_M1, hash::CONST_M0};
   state[5] ^= consts[rm_bytes < hash::RATE];
 
   hash::feistel<384ul>(state, buffer);

--- a/include/esch256.hpp
+++ b/include/esch256.hpp
@@ -36,32 +36,7 @@ hash(const uint8_t* const __restrict in, // input message
   size_t rm_bytes = ilen;
   while (rm_bytes > hash::RATE) {
     const size_t b_off = ilen - rm_bytes;
-
-    if constexpr (sparkle_utils::is_little_endian()) {
-      std::memcpy(buffer, in + b_off, hash::RATE);
-    } else {
-#if defined __clang__
-      // Following
-      // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
-
-#pragma clang loop unroll(enable)
-#pragma clang loop vectorize(enable)
-#elif defined __GNUG__
-      // Following
-      // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
-
-#pragma GCC ivdep
-#pragma GCC unroll 4
-#endif
-      for (size_t j = 0; j < 4; j++) {
-        const size_t i_off = j << 2;
-
-        buffer[j] = (static_cast<uint32_t>(in[b_off + (i_off + 3)]) << 24) |
-                    (static_cast<uint32_t>(in[b_off + (i_off + 2)]) << 16) |
-                    (static_cast<uint32_t>(in[b_off + (i_off + 1)]) << 8) |
-                    (static_cast<uint32_t>(in[b_off + (i_off + 0)]) << 0);
-      }
-    }
+    sparkle_utils::copy_le_bytes_to_words<hash::RATE>(in + b_off, buffer);
 
     hash::feistel<384ul>(state, buffer);
     sparkle::sparkle<6ul, 7ul>(state);
@@ -71,29 +46,15 @@ hash(const uint8_t* const __restrict in, // input message
 
   const size_t b_off = ilen - rm_bytes;
   const size_t rb_full_words = rm_bytes >> 2;
+  const size_t rb_full_bytes = rb_full_words << 2;
   const size_t rb_rem_bytes = rm_bytes & 3ul;
+  const size_t off = b_off + rb_full_bytes;
 
   std::memset(buffer, 0, hash::RATE);
-
-  if constexpr (sparkle_utils::is_little_endian()) {
-    std::memcpy(buffer, in + b_off, rb_full_words << 2);
-  } else {
-    for (size_t i = 0; i < rb_full_words; i++) {
-      const size_t off = i << 2;
-
-      buffer[i] = (static_cast<uint32_t>(in[b_off + (off + 3)]) << 24) |
-                  (static_cast<uint32_t>(in[b_off + (off + 2)]) << 16) |
-                  (static_cast<uint32_t>(in[b_off + (off + 1)]) << 8) |
-                  (static_cast<uint32_t>(in[b_off + (off + 0)]) << 0);
-    }
-  }
+  sparkle_utils::copy_le_bytes_to_words(in + b_off, buffer, rb_full_bytes);
 
   uint32_t word = 0x80u << (rb_rem_bytes << 3);
-  const size_t off = rb_full_words << 2;
-
-  for (size_t i = 0; i < rb_rem_bytes; i++) {
-    word |= static_cast<uint32_t>(in[b_off + off + i]) << (i << 3);
-  }
+  sparkle_utils::copy_le_bytes_to_words(in + off, &word, rb_rem_bytes);
 
   const uint32_t words[]{ 0u, word };
   buffer[rb_full_words] = words[rb_full_words < 4];
@@ -104,61 +65,9 @@ hash(const uint8_t* const __restrict in, // input message
   hash::feistel<384ul>(state, buffer);
   sparkle::sparkle<6ul, 11ul>(state);
 
-  if constexpr (sparkle_utils::is_little_endian()) {
-    std::memcpy(out, state, hash::RATE);
-  } else {
-#if defined __clang__
-    // Following
-    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
-
-#pragma clang loop unroll(enable)
-#pragma clang loop vectorize(enable)
-#elif defined __GNUG__
-    // Following
-    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
-
-#pragma GCC ivdep
-#pragma GCC unroll 4
-#endif
-    for (size_t i = 0; i < 4; i++) {
-      const uint32_t word = state[i];
-      const size_t b_off = i << 2;
-
-      out[b_off + 0] = static_cast<uint8_t>(word >> 0);
-      out[b_off + 1] = static_cast<uint8_t>(word >> 8);
-      out[b_off + 2] = static_cast<uint8_t>(word >> 16);
-      out[b_off + 3] = static_cast<uint8_t>(word >> 24);
-    }
-  }
-
+  sparkle_utils::copy_words_to_le_bytes<hash::RATE>(state, out);
   sparkle::sparkle<6ul, 7ul>(state);
-
-  if constexpr (sparkle_utils::is_little_endian()) {
-    std::memcpy(out + hash::RATE, state, hash::RATE);
-  } else {
-#if defined __clang__
-    // Following
-    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
-
-#pragma clang loop unroll(enable)
-#pragma clang loop vectorize(enable)
-#elif defined __GNUG__
-    // Following
-    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
-
-#pragma GCC ivdep
-#pragma GCC unroll 4
-#endif
-    for (size_t i = 0; i < 4; i++) {
-      const uint32_t word = state[i];
-      const size_t b_off = i << 2;
-
-      out[16ul + (b_off + 0)] = static_cast<uint8_t>(word >> 0);
-      out[16ul + (b_off + 1)] = static_cast<uint8_t>(word >> 8);
-      out[16ul + (b_off + 2)] = static_cast<uint8_t>(word >> 16);
-      out[16ul + (b_off + 3)] = static_cast<uint8_t>(word >> 24);
-    }
-  }
+  sparkle_utils::copy_words_to_le_bytes<hash::RATE>(state, out + hash::RATE);
 }
 
 } // namespace esch256

--- a/include/esch384.hpp
+++ b/include/esch384.hpp
@@ -44,17 +44,18 @@ hash(const uint8_t* const __restrict in, // input message
     r_bytes -= hash::RATE;
   }
 
-  const size_t b_off = ilen - r_bytes;
+  size_t b_off = ilen - r_bytes;
+
   const size_t rb_full_words = r_bytes >> 2;
   const size_t rb_full_bytes = rb_full_words << 2;
   const size_t rb_rem_bytes = r_bytes & 3ul;
-  const size_t off = b_off + rb_full_bytes;
 
   std::memset(buffer, 0, hash::RATE);
   sparkle_utils::copy_le_bytes_to_words(in + b_off, buffer, rb_full_bytes);
+  b_off += rb_full_bytes;
 
   uint32_t word = 0x80u << (rb_rem_bytes << 3);
-  sparkle_utils::copy_le_bytes_to_words(in + off, &word, rb_rem_bytes);
+  sparkle_utils::copy_le_bytes_to_words(in + b_off, &word, rb_rem_bytes);
 
   const uint32_t words[2] = { 0u, word };
   buffer[rb_full_words] = words[rb_full_words < 4];

--- a/include/esch384.hpp
+++ b/include/esch384.hpp
@@ -7,6 +7,9 @@
 // Esch384 hash function, based on Sparkle permutation
 namespace esch384 {
 
+// Esch384 hash function produces 48 -bytes of digest
+constexpr size_t DIGEST_LEN = 48;
+
 // Esch384 --- lightweight, cryptographically secure hash function, based on
 // Sparkle permutation, producing 48 -bytes digest from N -bytes input | N >= 0
 //

--- a/include/esch384.hpp
+++ b/include/esch384.hpp
@@ -24,11 +24,12 @@ constexpr size_t DIGEST_LEN = 48;
 //
 // See algorithm 2.10 of Sparkle specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline void hash(
-    const uint8_t* const __restrict in,  // input message
-    const size_t ilen,                   // len(in) = N | N >= 0
-    uint8_t* const __restrict out        // 48 -bytes output digest
-) {
+static inline void
+hash(const uint8_t* const __restrict in, // input message
+     const size_t ilen,                  // len(in) = N | N >= 0
+     uint8_t* const __restrict out       // 48 -bytes output digest
+)
+{
   uint32_t state[16]{};
   uint32_t buffer[8]{};
 
@@ -94,10 +95,10 @@ static inline void hash(
     word |= static_cast<uint32_t>(in[b_off + off + i]) << (i << 3);
   }
 
-  const uint32_t words[2] = {0u, word};
+  const uint32_t words[2] = { 0u, word };
   buffer[rb_full_words] = words[rb_full_words < 4];
 
-  constexpr uint32_t consts[2] = {hash::CONST_M1, hash::CONST_M0};
+  constexpr uint32_t consts[2] = { hash::CONST_M1, hash::CONST_M0 };
   state[7] ^= consts[r_bytes < hash::RATE];
 
   hash::feistel<512ul>(state, buffer);
@@ -189,4 +190,4 @@ static inline void hash(
   }
 }
 
-}  // namespace esch384
+} // namespace esch384

--- a/include/esch384.hpp
+++ b/include/esch384.hpp
@@ -37,7 +37,7 @@ hash(const uint8_t* const __restrict in, // input message
   while (r_bytes > hash::RATE) {
     const size_t b_off = ilen - r_bytes;
 
-    if constexpr (is_little_endian()) {
+    if constexpr (sparkle_utils::is_little_endian()) {
       std::memcpy(buffer, in + b_off, hash::RATE);
     } else {
 #if defined __clang__
@@ -75,7 +75,7 @@ hash(const uint8_t* const __restrict in, // input message
 
   std::memset(buffer, 0, hash::RATE);
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(buffer, in + b_off, rb_full_words << 2);
   } else {
     for (size_t i = 0; i < rb_full_words; i++) {
@@ -104,7 +104,7 @@ hash(const uint8_t* const __restrict in, // input message
   hash::feistel<512ul>(state, buffer);
   sparkle::sparkle<8ul, 12ul>(state);
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(out, state, hash::RATE);
   } else {
 #if defined __clang__
@@ -133,7 +133,7 @@ hash(const uint8_t* const __restrict in, // input message
 
   sparkle::sparkle<8ul, 8ul>(state);
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(out + hash::RATE, state, hash::RATE);
   } else {
 #if defined __clang__
@@ -162,7 +162,7 @@ hash(const uint8_t* const __restrict in, // input message
 
   sparkle::sparkle<8ul, 8ul>(state);
 
-  if constexpr (is_little_endian()) {
+  if constexpr (sparkle_utils::is_little_endian()) {
     std::memcpy(out + (hash::RATE << 1), state, hash::RATE);
   } else {
 #if defined __clang__

--- a/include/hash.hpp
+++ b/include/hash.hpp
@@ -31,9 +31,10 @@ constexpr uint32_t CONST_M1 = 2u << 24;
 //
 // See section 2.2.2 of Sparkle specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-template <const size_t state_w>
-static inline void feistel(uint32_t* const __restrict state,
-                           const uint32_t* const __restrict msg) {
+template<const size_t state_w>
+static inline void
+feistel(uint32_t* const __restrict state, const uint32_t* const __restrict msg)
+{
   // This branch is taken when computing Esch256 hash
   //
   // Note, in Esch256 sparkle permutation variant Sparkle384 is used
@@ -80,4 +81,4 @@ static inline void feistel(uint32_t* const __restrict state,
   }
 }
 
-}  // namespace hash
+} // namespace hash

--- a/include/hash.hpp
+++ b/include/hash.hpp
@@ -39,6 +39,8 @@ static inline void feistel(uint32_t* const __restrict state,
   // Note, in Esch256 sparkle permutation variant Sparkle384 is used
   // which has state bit width of 384
   if constexpr (state_w == 384ul) {
+    static_assert(state_w == 384, "State bit width must be = 384 -bits");
+
     uint32_t tx = msg[0] ^ msg[2];
     uint32_t ty = msg[1] ^ msg[3];
 
@@ -57,7 +59,9 @@ static inline void feistel(uint32_t* const __restrict state,
   //
   // Note, in Esch384 sparkle permutation variant Sparkle512 is used
   // which has state bit width of 512
-  else if constexpr (state_w == 512ul) {
+  else {
+    static_assert(state_w == 512, "State bit width must be = 512 -bits");
+
     uint32_t tx = msg[0] ^ msg[2];
     uint32_t ty = msg[1] ^ msg[3];
 

--- a/include/schwaemm.hpp
+++ b/include/schwaemm.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "schwaemm128_128.hpp"
+#include "schwaemm192_192.hpp"
+#include "schwaemm256_128.hpp"
+#include "schwaemm256_256.hpp"

--- a/include/schwaemm128_128.hpp
+++ b/include/schwaemm128_128.hpp
@@ -53,18 +53,19 @@ constexpr uint32_t M1 = (3u ^ (1u << 2)) << 24;
 //
 // See algorithm 2.17 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline void encrypt(
-    const uint8_t* const __restrict key,    // 16 -bytes secret key
-    const uint8_t* const __restrict nonce,  // 16 -bytes nonce
-    const uint8_t* const __restrict data,   // N (>=0) -bytes associated data
-    const size_t d_len,                     // len(data) = N | N >= 0
-    const uint8_t* const __restrict txt,    // N (>=0) -bytes plain text
-    uint8_t* const __restrict enc,          // N (>=0) -bytes cipher text
-    const size_t ct_len,                    // len(txt) = len(enc) = N | >= 0
-    uint8_t* const __restrict tag           // 16 -bytes authentication tag
-) {
-  aead::encrypt<R, C, A0, A1, M0, M1, BR, S, B>(key, nonce, data, d_len, txt,
-                                                enc, ct_len, tag);
+static inline void
+encrypt(const uint8_t* const __restrict key,   // 16 -bytes secret key
+        const uint8_t* const __restrict nonce, // 16 -bytes nonce
+        const uint8_t* const __restrict data,  // N (>=0) -bytes associated data
+        const size_t d_len,                    // len(data) = N | N >= 0
+        const uint8_t* const __restrict txt,   // N (>=0) -bytes plain text
+        uint8_t* const __restrict enc,         // N (>=0) -bytes cipher text
+        const size_t ct_len,                   // len(txt) = len(enc) = N | >= 0
+        uint8_t* const __restrict tag          // 16 -bytes authentication tag
+)
+{
+  aead::encrypt<R, C, A0, A1, M0, M1, BR, S, B>(
+    key, nonce, data, d_len, txt, enc, ct_len, tag);
 }
 
 // Schwaemm128-128 verified decryption, which computes N (>=0) -bytes of
@@ -83,18 +84,19 @@ static inline void encrypt(
 //
 // See algorithm 2.18 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline bool decrypt(
-    const uint8_t* const __restrict key,    // 16 -bytes secret key
-    const uint8_t* const __restrict nonce,  // 16 -bytes nonce
-    const uint8_t* const __restrict tag,    // 16 -bytes authentication tag
-    const uint8_t* const __restrict data,   // N (>=0) -bytes associated data
-    const size_t d_len,                     // len(data) = N | N >= 0
-    const uint8_t* const __restrict enc,    // N (>=0) -bytes encrypted text
-    uint8_t* const __restrict dec,          // N (>=0) -bytes decrypted text
-    const size_t ct_len                     // len(enc) = len(dec) = N | >= 0
-) {
-  return aead::decrypt<R, C, A0, A1, M0, M1, BR, S, B>(key, nonce, tag, data,
-                                                       d_len, enc, dec, ct_len);
+static inline bool
+decrypt(const uint8_t* const __restrict key,   // 16 -bytes secret key
+        const uint8_t* const __restrict nonce, // 16 -bytes nonce
+        const uint8_t* const __restrict tag,   // 16 -bytes authentication tag
+        const uint8_t* const __restrict data,  // N (>=0) -bytes associated data
+        const size_t d_len,                    // len(data) = N | N >= 0
+        const uint8_t* const __restrict enc,   // N (>=0) -bytes encrypted text
+        uint8_t* const __restrict dec,         // N (>=0) -bytes decrypted text
+        const size_t ct_len                    // len(enc) = len(dec) = N | >= 0
+)
+{
+  return aead::decrypt<R, C, A0, A1, M0, M1, BR, S, B>(
+    key, nonce, tag, data, d_len, enc, dec, ct_len);
 }
 
-}  // namespace schwaemm128_128
+} // namespace schwaemm128_128

--- a/include/schwaemm192_192.hpp
+++ b/include/schwaemm192_192.hpp
@@ -53,18 +53,19 @@ constexpr uint32_t M1 = (3u ^ (1u << 3)) << 24;
 //
 // See algorithm 2.15 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline void encrypt(
-    const uint8_t* const __restrict key,    // 24 -bytes secret key
-    const uint8_t* const __restrict nonce,  // 24 -bytes nonce
-    const uint8_t* const __restrict data,   // N (>=0) -bytes associated data
-    const size_t d_len,                     // len(data) = N | N >= 0
-    const uint8_t* const __restrict txt,    // N (>=0) -bytes plain text
-    uint8_t* const __restrict enc,          // N (>=0) -bytes cipher text
-    const size_t ct_len,                    // len(txt) = len(enc) = N | >= 0
-    uint8_t* const __restrict tag           // 24 -bytes authentication tag
-) {
-  aead::encrypt<R, C, A0, A1, M0, M1, BR, S, B>(key, nonce, data, d_len, txt,
-                                                enc, ct_len, tag);
+static inline void
+encrypt(const uint8_t* const __restrict key,   // 24 -bytes secret key
+        const uint8_t* const __restrict nonce, // 24 -bytes nonce
+        const uint8_t* const __restrict data,  // N (>=0) -bytes associated data
+        const size_t d_len,                    // len(data) = N | N >= 0
+        const uint8_t* const __restrict txt,   // N (>=0) -bytes plain text
+        uint8_t* const __restrict enc,         // N (>=0) -bytes cipher text
+        const size_t ct_len,                   // len(txt) = len(enc) = N | >= 0
+        uint8_t* const __restrict tag          // 24 -bytes authentication tag
+)
+{
+  aead::encrypt<R, C, A0, A1, M0, M1, BR, S, B>(
+    key, nonce, data, d_len, txt, enc, ct_len, tag);
 }
 
 // Schwaemm192-192 verified decryption, which computes N (>=0) -bytes of
@@ -83,18 +84,19 @@ static inline void encrypt(
 //
 // See algorithm 2.16 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline bool decrypt(
-    const uint8_t* const __restrict key,    // 24 -bytes secret key
-    const uint8_t* const __restrict nonce,  // 24 -bytes nonce
-    const uint8_t* const __restrict tag,    // 24 -bytes authentication tag
-    const uint8_t* const __restrict data,   // N (>=0) -bytes associated data
-    const size_t d_len,                     // len(data) = N | N >= 0
-    const uint8_t* const __restrict enc,    // N (>=0) -bytes encrypted text
-    uint8_t* const __restrict dec,          // N (>=0) -bytes decrypted text
-    const size_t ct_len                     // len(enc) = len(dec) = N | >= 0
-) {
-  return aead::decrypt<R, C, A0, A1, M0, M1, BR, S, B>(key, nonce, tag, data,
-                                                       d_len, enc, dec, ct_len);
+static inline bool
+decrypt(const uint8_t* const __restrict key,   // 24 -bytes secret key
+        const uint8_t* const __restrict nonce, // 24 -bytes nonce
+        const uint8_t* const __restrict tag,   // 24 -bytes authentication tag
+        const uint8_t* const __restrict data,  // N (>=0) -bytes associated data
+        const size_t d_len,                    // len(data) = N | N >= 0
+        const uint8_t* const __restrict enc,   // N (>=0) -bytes encrypted text
+        uint8_t* const __restrict dec,         // N (>=0) -bytes decrypted text
+        const size_t ct_len                    // len(enc) = len(dec) = N | >= 0
+)
+{
+  return aead::decrypt<R, C, A0, A1, M0, M1, BR, S, B>(
+    key, nonce, tag, data, d_len, enc, dec, ct_len);
 }
 
-}  // namespace schwaemm192_192
+} // namespace schwaemm192_192

--- a/include/schwaemm256_128.hpp
+++ b/include/schwaemm256_128.hpp
@@ -52,18 +52,19 @@ constexpr uint32_t M1 = (3u ^ (1u << 2)) << 24;
 //
 // See algorithm 2.13 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline void encrypt(
-    const uint8_t* const __restrict key,    // 16 -bytes secret key
-    const uint8_t* const __restrict nonce,  // 32 -bytes nonce
-    const uint8_t* const __restrict data,   // N (>=0) -bytes associated data
-    const size_t d_len,                     // len(data) = N | N >= 0
-    const uint8_t* const __restrict txt,    // N (>=0) -bytes plain text
-    uint8_t* const __restrict enc,          // N (>=0) -bytes cipher text
-    const size_t ct_len,                    // len(txt) = len(enc) = N | >= 0
-    uint8_t* const __restrict tag           // 16 -bytes authentication tag
-) {
-  aead::encrypt<R, C, A0, A1, M0, M1, BR, S, B>(key, nonce, data, d_len, txt,
-                                                enc, ct_len, tag);
+static inline void
+encrypt(const uint8_t* const __restrict key,   // 16 -bytes secret key
+        const uint8_t* const __restrict nonce, // 32 -bytes nonce
+        const uint8_t* const __restrict data,  // N (>=0) -bytes associated data
+        const size_t d_len,                    // len(data) = N | N >= 0
+        const uint8_t* const __restrict txt,   // N (>=0) -bytes plain text
+        uint8_t* const __restrict enc,         // N (>=0) -bytes cipher text
+        const size_t ct_len,                   // len(txt) = len(enc) = N | >= 0
+        uint8_t* const __restrict tag          // 16 -bytes authentication tag
+)
+{
+  aead::encrypt<R, C, A0, A1, M0, M1, BR, S, B>(
+    key, nonce, data, d_len, txt, enc, ct_len, tag);
 }
 
 // Schwaemm256-128 verified decryption, which computes N (>=0) -bytes of
@@ -81,18 +82,19 @@ static inline void encrypt(
 //
 // See algorithm 2.14 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline bool decrypt(
-    const uint8_t* const __restrict key,    // 16 -bytes secret key
-    const uint8_t* const __restrict nonce,  // 32 -bytes nonce
-    const uint8_t* const __restrict tag,    // 16 -bytes authentication tag
-    const uint8_t* const __restrict data,   // N (>=0) -bytes associated data
-    const size_t d_len,                     // len(data) = N | N >= 0
-    const uint8_t* const __restrict enc,    // N (>=0) -bytes encrypted text
-    uint8_t* const __restrict dec,          // N (>=0) -bytes decrypted text
-    const size_t ct_len                     // len(enc) = len(dec) = N | >= 0
-) {
-  return aead::decrypt<R, C, A0, A1, M0, M1, BR, S, B>(key, nonce, tag, data,
-                                                       d_len, enc, dec, ct_len);
+static inline bool
+decrypt(const uint8_t* const __restrict key,   // 16 -bytes secret key
+        const uint8_t* const __restrict nonce, // 32 -bytes nonce
+        const uint8_t* const __restrict tag,   // 16 -bytes authentication tag
+        const uint8_t* const __restrict data,  // N (>=0) -bytes associated data
+        const size_t d_len,                    // len(data) = N | N >= 0
+        const uint8_t* const __restrict enc,   // N (>=0) -bytes encrypted text
+        uint8_t* const __restrict dec,         // N (>=0) -bytes decrypted text
+        const size_t ct_len                    // len(enc) = len(dec) = N | >= 0
+)
+{
+  return aead::decrypt<R, C, A0, A1, M0, M1, BR, S, B>(
+    key, nonce, tag, data, d_len, enc, dec, ct_len);
 }
 
-}  // namespace schwaemm256_128
+} // namespace schwaemm256_128

--- a/include/schwaemm256_256.hpp
+++ b/include/schwaemm256_256.hpp
@@ -53,18 +53,19 @@ constexpr uint32_t M1 = (3u ^ (1u << 4)) << 24;
 //
 // See algorithm 2.19 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline void encrypt(
-    const uint8_t* const __restrict key,    // 32 -bytes secret key
-    const uint8_t* const __restrict nonce,  // 32 -bytes nonce
-    const uint8_t* const __restrict data,   // N (>=0) -bytes associated data
-    const size_t d_len,                     // len(data) = N | N >= 0
-    const uint8_t* const __restrict txt,    // N (>=0) -bytes plain text
-    uint8_t* const __restrict enc,          // N (>=0) -bytes cipher text
-    const size_t ct_len,                    // len(txt) = len(enc) = N | >= 0
-    uint8_t* const __restrict tag           // 32 -bytes authentication tag
-) {
-  aead::encrypt<R, C, A0, A1, M0, M1, BR, S, B>(key, nonce, data, d_len, txt,
-                                                enc, ct_len, tag);
+static inline void
+encrypt(const uint8_t* const __restrict key,   // 32 -bytes secret key
+        const uint8_t* const __restrict nonce, // 32 -bytes nonce
+        const uint8_t* const __restrict data,  // N (>=0) -bytes associated data
+        const size_t d_len,                    // len(data) = N | N >= 0
+        const uint8_t* const __restrict txt,   // N (>=0) -bytes plain text
+        uint8_t* const __restrict enc,         // N (>=0) -bytes cipher text
+        const size_t ct_len,                   // len(txt) = len(enc) = N | >= 0
+        uint8_t* const __restrict tag          // 32 -bytes authentication tag
+)
+{
+  aead::encrypt<R, C, A0, A1, M0, M1, BR, S, B>(
+    key, nonce, data, d_len, txt, enc, ct_len, tag);
 }
 
 // Schwaemm256-256 verified decryption, which computes N (>=0) -bytes of
@@ -83,18 +84,19 @@ static inline void encrypt(
 //
 // See algorithm 2.20 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline bool decrypt(
-    const uint8_t* const __restrict key,    // 32 -bytes secret key
-    const uint8_t* const __restrict nonce,  // 32 -bytes nonce
-    const uint8_t* const __restrict tag,    // 32 -bytes authentication tag
-    const uint8_t* const __restrict data,   // N (>=0) -bytes associated data
-    const size_t d_len,                     // len(data) = N | N >= 0
-    const uint8_t* const __restrict enc,    // N (>=0) -bytes encrypted text
-    uint8_t* const __restrict dec,          // N (>=0) -bytes decrypted text
-    const size_t ct_len                     // len(enc) = len(dec) = N | >= 0
-) {
-  return aead::decrypt<R, C, A0, A1, M0, M1, BR, S, B>(key, nonce, tag, data,
-                                                       d_len, enc, dec, ct_len);
+static inline bool
+decrypt(const uint8_t* const __restrict key,   // 32 -bytes secret key
+        const uint8_t* const __restrict nonce, // 32 -bytes nonce
+        const uint8_t* const __restrict tag,   // 32 -bytes authentication tag
+        const uint8_t* const __restrict data,  // N (>=0) -bytes associated data
+        const size_t d_len,                    // len(data) = N | N >= 0
+        const uint8_t* const __restrict enc,   // N (>=0) -bytes encrypted text
+        uint8_t* const __restrict dec,         // N (>=0) -bytes decrypted text
+        const size_t ct_len                    // len(enc) = len(dec) = N | >= 0
+)
+{
+  return aead::decrypt<R, C, A0, A1, M0, M1, BR, S, B>(
+    key, nonce, tag, data, d_len, enc, dec, ct_len);
 }
 
-}  // namespace schwaemm256_256
+} // namespace schwaemm256_256

--- a/include/sparkle.hpp
+++ b/include/sparkle.hpp
@@ -10,18 +10,19 @@ namespace sparkle {
 // Sparkle constants which are XORed into permutation state, see first four
 // lines of algorithm 2.{1, 2, 3} in Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-constexpr uint32_t CONST[8] = {0xB7E15162u, 0xBF715880u, 0x38B4DA56u,
-                               0x324E7738u, 0xBB1185EBu, 0x4F7C7B57u,
-                               0xCFBFA1C8u, 0xC2B3293Du};
+constexpr uint32_t CONST[]{
+  0xB7E15162u, 0xBF715880u, 0x38B4DA56u, 0x324E7738u,
+  0xBB1185EBu, 0x4F7C7B57u, 0xCFBFA1C8u, 0xC2B3293Du
+};
 
 // ARX-box Alzette is a 64 -bit block cipher used as one building block of
 // Sparkle Permutation
 //
 // See section 2.1.1 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline std::pair<uint32_t, uint32_t> alzette(const uint32_t x,
-                                                    const uint32_t y,
-                                                    const uint32_t c) {
+static inline std::pair<uint32_t, uint32_t>
+alzette(const uint32_t x, const uint32_t y, const uint32_t c)
+{
   uint32_t lw = x + std::rotr(y, 31);
   uint32_t rw = y ^ std::rotr(lw, 24);
   lw ^= c;
@@ -46,7 +47,9 @@ static inline std::pair<uint32_t, uint32_t> alzette(const uint32_t x,
 //
 // See algorithm 2.5 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline void diffusion_layer_4(uint32_t* const state) {
+static inline void
+diffusion_layer_4(uint32_t* const state)
+{
   // feistel round
 
   uint32_t tx = state[0] ^ state[2];
@@ -85,7 +88,9 @@ static inline void diffusion_layer_4(uint32_t* const state) {
 //
 // See algorithm 2.6 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline void diffusion_layer_6(uint32_t* const state) {
+static inline void
+diffusion_layer_6(uint32_t* const state)
+{
   // feistel round
 
   uint32_t tx = state[0] ^ state[2] ^ state[4];
@@ -132,7 +137,9 @@ static inline void diffusion_layer_6(uint32_t* const state) {
 //
 // See algorithm 2.6 of Sparkle Specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-static inline void diffusion_layer_8(uint32_t* const state) {
+static inline void
+diffusion_layer_8(uint32_t* const state)
+{
   // feistel round
 
   uint32_t tx = state[0] ^ state[2] ^ state[4] ^ state[6];
@@ -186,7 +193,9 @@ static inline void diffusion_layer_8(uint32_t* const state) {
 // permutation, are conformant i.e. as provided in table 2.1 of the Sparkle
 // specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
-consteval bool check_nb_ns(const size_t nb, const size_t ns) {
+consteval bool
+check_nb_ns(const size_t nb, const size_t ns)
+{
   return ((nb == 4) && ((ns == 7) || (ns == 10))) ||
          ((nb == 6) && ((ns == 7) || (ns == 11))) ||
          ((nb == 8) && ((ns == 8) || (ns == 12)));
@@ -202,10 +211,10 @@ consteval bool check_nb_ns(const size_t nb, const size_t ns) {
 //
 // For implementation specific details, I suggest going through
 // algorithm 2.1, 2.2 & 2.3 of above linked document.
-template <const size_t nb, const size_t ns>
-static inline void sparkle(
-    uint32_t* const state  // 32 * (nb * 2) -bit wide state
-    )
+template<const size_t nb, const size_t ns>
+static inline void
+sparkle(uint32_t* const state // 32 * (nb * 2) -bit wide state
+        )
   requires(check_nb_ns(nb, ns))
 {
   for (size_t i = 0; i < ns; i++) {
@@ -297,4 +306,4 @@ static inline void sparkle(
   }
 }
 
-}  // namespace sparkle
+} // namespace sparkle

--- a/include/sparkle.hpp
+++ b/include/sparkle.hpp
@@ -55,29 +55,29 @@ static inline void diffusion_layer_4(uint32_t* const state) {
   tx = std::rotl(tx ^ (tx << 16), 16);
   ty = std::rotl(ty ^ (ty << 16), 16);
 
-  state[5] = state[5] ^ state[1] ^ tx;
-  state[7] = state[7] ^ state[3] ^ tx;
+  state[5] ^= state[1] ^ tx;
+  state[7] ^= state[3] ^ tx;
 
-  state[4] = state[4] ^ state[0] ^ ty;
-  state[6] = state[6] ^ state[2] ^ ty;
+  state[4] ^= state[0] ^ ty;
+  state[6] ^= state[2] ^ ty;
 
   // branch permutation
 
-  uint32_t t0 = state[4];
-  uint32_t t1 = state[6];
+  const auto t0 = state[4];
+  const auto t1 = state[6];
 
   state[4] = state[0];
   state[6] = state[2];
   state[0] = t1;
   state[2] = t0;
 
-  t0 = state[5];
-  t1 = state[7];
+  const auto t2 = state[5];
+  const auto t3 = state[7];
 
   state[5] = state[1];
   state[7] = state[3];
-  state[1] = t1;
-  state[3] = t0;
+  state[1] = t3;
+  state[3] = t2;
 }
 
 // Diffusion Layer `ℒ6`, used when branch count = 6 i.e. permutation state
@@ -94,19 +94,19 @@ static inline void diffusion_layer_6(uint32_t* const state) {
   tx = std::rotl(tx ^ (tx << 16), 16);
   ty = std::rotl(ty ^ (ty << 16), 16);
 
-  state[7] = state[7] ^ state[1] ^ tx;
-  state[9] = state[9] ^ state[3] ^ tx;
-  state[11] = state[11] ^ state[5] ^ tx;
+  state[7] ^= state[1] ^ tx;
+  state[9] ^= state[3] ^ tx;
+  state[11] ^= state[5] ^ tx;
 
-  state[6] = state[6] ^ state[0] ^ ty;
-  state[8] = state[8] ^ state[2] ^ ty;
-  state[10] = state[10] ^ state[4] ^ ty;
+  state[6] ^= state[0] ^ ty;
+  state[8] ^= state[2] ^ ty;
+  state[10] ^= state[4] ^ ty;
 
   // branch permutation
 
-  uint32_t t0 = state[6];
-  uint32_t t1 = state[8];
-  uint32_t t2 = state[10];
+  const auto t0 = state[6];
+  const auto t1 = state[8];
+  const auto t2 = state[10];
 
   state[6] = state[0];
   state[8] = state[2];
@@ -115,16 +115,16 @@ static inline void diffusion_layer_6(uint32_t* const state) {
   state[2] = t2;
   state[4] = t0;
 
-  t0 = state[7];
-  t1 = state[9];
-  t2 = state[11];
+  const auto t3 = state[7];
+  const auto t4 = state[9];
+  const auto t5 = state[11];
 
   state[7] = state[1];
   state[9] = state[3];
   state[11] = state[5];
-  state[1] = t1;
-  state[3] = t2;
-  state[5] = t0;
+  state[1] = t4;
+  state[3] = t5;
+  state[5] = t3;
 }
 
 // Diffusion Layer `ℒ8`, used when branch count = 8 i.e. permutation state
@@ -141,22 +141,22 @@ static inline void diffusion_layer_8(uint32_t* const state) {
   tx = std::rotl(tx ^ (tx << 16), 16);
   ty = std::rotl(ty ^ (ty << 16), 16);
 
-  state[9] = state[9] ^ state[1] ^ tx;
-  state[11] = state[11] ^ state[3] ^ tx;
-  state[13] = state[13] ^ state[5] ^ tx;
-  state[15] = state[15] ^ state[7] ^ tx;
+  state[9] ^= state[1] ^ tx;
+  state[11] ^= state[3] ^ tx;
+  state[13] ^= state[5] ^ tx;
+  state[15] ^= state[7] ^ tx;
 
-  state[8] = state[8] ^ state[0] ^ ty;
-  state[10] = state[10] ^ state[2] ^ ty;
-  state[12] = state[12] ^ state[4] ^ ty;
-  state[14] = state[14] ^ state[6] ^ ty;
+  state[8] ^= state[0] ^ ty;
+  state[10] ^= state[2] ^ ty;
+  state[12] ^= state[4] ^ ty;
+  state[14] ^= state[6] ^ ty;
 
   // branch permutation
 
-  uint32_t t0 = state[8];
-  uint32_t t1 = state[10];
-  uint32_t t2 = state[12];
-  uint32_t t3 = state[14];
+  const auto t0 = state[8];
+  const auto t1 = state[10];
+  const auto t2 = state[12];
+  const auto t3 = state[14];
 
   state[8] = state[0];
   state[10] = state[2];
@@ -167,19 +167,19 @@ static inline void diffusion_layer_8(uint32_t* const state) {
   state[4] = t3;
   state[6] = t0;
 
-  t0 = state[9];
-  t1 = state[11];
-  t2 = state[13];
-  t3 = state[15];
+  const auto t4 = state[9];
+  const auto t5 = state[11];
+  const auto t6 = state[13];
+  const auto t7 = state[15];
 
   state[9] = state[1];
   state[11] = state[3];
   state[13] = state[5];
   state[15] = state[7];
-  state[1] = t1;
-  state[3] = t2;
-  state[5] = t3;
-  state[7] = t0;
+  state[1] = t5;
+  state[3] = t6;
+  state[5] = t7;
+  state[7] = t4;
 }
 
 // Generic Sparkle Permutation Implementation, parameterized with # -of branches

--- a/include/sparkle.hpp
+++ b/include/sparkle.hpp
@@ -184,7 +184,8 @@ static inline void diffusion_layer_8(uint32_t* const state) {
 
 // Generic Sparkle Permutation Implementation, parameterized with # -of branches
 // ( i.e. in Sparkle256 it is 4, in Sparkle384 it is 6 & in Sparkle512 it is 8 )
-// and # -of steps ( i.e. whether slim/ big variant )
+// and # -of steps ( i.e. whether slim/ big variant ), over state size of
+// 32 * (2 * nb) -bits.
 //
 // See section 2.1 of Sparkle specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
@@ -192,7 +193,9 @@ static inline void diffusion_layer_8(uint32_t* const state) {
 // For implementation specific details, I suggest going through
 // algorithm 2.1, 2.2 & 2.3 of above linked document.
 template <const size_t nb, const size_t ns>
-static inline void sparkle(uint32_t* const state) {
+static inline void sparkle(
+    uint32_t* const state  // 32 * (nb * 2) -bit wide state
+) {
   for (size_t i = 0; i < ns; i++) {
     state[1] = state[1] ^ CONST[i & 7ul];
     state[3] = state[3] ^ static_cast<uint32_t>(i);

--- a/include/sparkle.hpp
+++ b/include/sparkle.hpp
@@ -182,6 +182,16 @@ static inline void diffusion_layer_8(uint32_t* const state) {
   state[7] = t4;
 }
 
+// Compile-time check to ensure that # -of branches and # -of steps, for Sparkle
+// permutation, are conformant i.e. as provided in table 2.1 of the Sparkle
+// specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/sparkle-spec-final.pdf
+consteval bool check_nb_ns(const size_t nb, const size_t ns) {
+  return ((nb == 4) && ((ns == 7) || (ns == 10))) ||
+         ((nb == 6) && ((ns == 7) || (ns == 11))) ||
+         ((nb == 8) && ((ns == 8) || (ns == 12)));
+}
+
 // Generic Sparkle Permutation Implementation, parameterized with # -of branches
 // ( i.e. in Sparkle256 it is 4, in Sparkle384 it is 6 & in Sparkle512 it is 8 )
 // and # -of steps ( i.e. whether slim/ big variant ), over state size of
@@ -195,7 +205,9 @@ static inline void diffusion_layer_8(uint32_t* const state) {
 template <const size_t nb, const size_t ns>
 static inline void sparkle(
     uint32_t* const state  // 32 * (nb * 2) -bit wide state
-) {
+    )
+  requires(check_nb_ns(nb, ns))
+{
   for (size_t i = 0; i < ns; i++) {
     state[1] = state[1] ^ CONST[i & 7ul];
     state[3] = state[3] ^ static_cast<uint32_t>(i);

--- a/include/sparkle.hpp
+++ b/include/sparkle.hpp
@@ -198,14 +198,24 @@ static inline void sparkle(uint32_t* const state) {
     state[3] = state[3] ^ static_cast<uint32_t>(i);
 
     if constexpr (nb == 4ul) {
+      static_assert(nb == 4ul, "# -of branches must be = 4");
+
 #if defined __clang__
-#pragma unroll 4
+      // Following
+      // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
 #elif defined __GNUG__
+      // Following
+      // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
 #pragma GCC unroll 4
 #endif
-      for (size_t i = 0; i < 4; i++) {
-        const size_t x_idx = i << 1;
-        const size_t y_idx = x_idx ^ 1ul;
+      for (size_t i = 0; i < nb; i++) {
+        const size_t x_idx = i * 2;
+        const size_t y_idx = x_idx + 1ul;
 
         const auto p = alzette(state[x_idx], state[y_idx], CONST[i]);
 
@@ -215,14 +225,24 @@ static inline void sparkle(uint32_t* const state) {
 
       diffusion_layer_4(state);
     } else if constexpr (nb == 6ul) {
+      static_assert(nb == 6ul, "# -of branches must be = 6");
+
 #if defined __clang__
-#pragma unroll 4
+      // Following
+      // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
 #elif defined __GNUG__
-#pragma GCC unroll 4
+      // Following
+      // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
+#pragma GCC unroll 6
 #endif
-      for (size_t i = 0; i < 4; i++) {
-        const size_t x_idx = i << 1;
-        const size_t y_idx = x_idx ^ 1ul;
+      for (size_t i = 0; i < nb; i++) {
+        const size_t x_idx = i * 2;
+        const size_t y_idx = x_idx + 1ul;
 
         const auto p = alzette(state[x_idx], state[y_idx], CONST[i]);
 
@@ -230,31 +250,26 @@ static inline void sparkle(uint32_t* const state) {
         state[y_idx] = p.second;
       }
 
-#if defined __clang__
-#pragma unroll 2
-#elif defined __GNUG__
-#pragma GCC unroll 2
-#endif
-      for (size_t i = 0; i < 2; i++) {
-        const size_t x_idx = 8ul ^ (i << 1);
-        const size_t y_idx = x_idx ^ 1ul;
-
-        const auto p = alzette(state[x_idx], state[y_idx], CONST[4ul ^ i]);
-
-        state[x_idx] = p.first;
-        state[y_idx] = p.second;
-      }
-
       diffusion_layer_6(state);
     } else if constexpr (nb == 8ul) {
+      static_assert(nb == 8ul, "# -of branches must be = 8");
+
 #if defined __clang__
-#pragma unroll 4
+      // Following
+      // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
 #elif defined __GNUG__
-#pragma GCC unroll 4
+      // Following
+      // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
+#pragma GCC unroll 8
 #endif
-      for (size_t i = 0; i < 8; i++) {
-        const size_t x_idx = i << 1;
-        const size_t y_idx = x_idx ^ 1ul;
+      for (size_t i = 0; i < nb; i++) {
+        const size_t x_idx = i * 2;
+        const size_t y_idx = x_idx + 1ul;
 
         const auto p = alzette(state[x_idx], state[y_idx], CONST[i]);
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -6,6 +6,9 @@
 #include <random>
 #include <sstream>
 
+// Utility routines used in Sparkle Cipher Suite
+namespace sparkle_utils {
+
 consteval static inline bool
 is_little_endian()
 {
@@ -40,4 +43,6 @@ random_data(T* const data, const size_t len)
   for (size_t i = 0; i < len; i++) {
     data[i] = dis(gen);
   }
+}
+
 }

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -24,11 +24,14 @@ static inline const std::string to_hex(const uint8_t* const bytes,
   return ss.str();
 }
 
-// Generates N -many random bytes | N >= 0
-static inline void random_data(uint8_t* const data, const size_t len) {
+// Generates len (>=0) -many random elements of type T | T = unsigned integral
+template <typename T>
+static inline void random_data(T* const data, const size_t len)
+  requires(std::is_unsigned_v<T>)
+{
   std::random_device rd;
   std::mt19937_64 gen(rd());
-  std::uniform_int_distribution<uint8_t> dis;
+  std::uniform_int_distribution<T> dis;
 
   for (size_t i = 0; i < len; i++) {
     data[i] = dis(gen);

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -2,6 +2,7 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <iomanip>
 #include <random>
 #include <sstream>
@@ -9,10 +10,95 @@
 // Utility routines used in Sparkle Cipher Suite
 namespace sparkle_utils {
 
+// Given a 32 -bit unsigned integer word, this routine swaps byte order and
+// returns byte swapped 32 -bit word.
+//
+// Taken from
+// https://github.com/itzmeanjan/xoodyak/blob/89b3427/include/utils.hpp#L14-L28
+static inline constexpr uint32_t
+bswap32(const uint32_t a)
+{
+#if defined __GNUG__
+  return __builtin_bswap32(a);
+#else
+  return ((a & 0x000000ffu) << 24) | ((a & 0x0000ff00u) << 0x08) |
+         ((a & 0x00ff0000u) >> 0x08) | ((a & 0xff000000u) >> 24);
+#endif
+}
+
 consteval static inline bool
 is_little_endian()
 {
   return std::endian::native == std::endian::little;
+}
+
+// This routine copies `blen` -many bytes from the source byte array to the
+// destination array of unsigned 32 -bit words, following little-endian
+// byte-order. Ensure that to be copied bytes i.e. blen is evenly divisible
+// by 4.
+template<const size_t blen>
+static inline void
+copy_le_bytes_to_words(const uint8_t* const __restrict bytes,
+                       uint32_t* const __restrict words)
+{
+  static_assert(blen % 4 == 0, "Must be blen/4 -many full words");
+  std::memcpy(words, bytes, blen);
+
+  if constexpr (!is_little_endian()) {
+    constexpr size_t wlen = blen / 4;
+
+#if defined __clang__
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#elif defined __GNUG__
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
+#endif
+    for (size_t i = 0; i < wlen; i++) {
+      words[i] = bswap32(words[i]);
+    }
+  }
+}
+
+// This routine copies `blen` -many bytes from the source u32 word array to the
+// destination byte array, following little-endian byte-order. Ensure that to be
+// copied bytes i.e. blen is evenly divisible by 4.
+template<const size_t blen>
+static inline void
+copy_words_to_le_bytes(const uint32_t* const __restrict words,
+                       uint8_t* const __restrict bytes)
+{
+  static_assert(blen % 4 == 0, "Must be blen/4 -many full words");
+
+  if constexpr (is_little_endian()) {
+    std::memcpy(bytes, words, blen);
+  } else {
+    constexpr size_t wlen = blen / 4;
+
+#if defined __clang__
+    // Following
+    // https://clang.llvm.org/docs/LanguageExtensions.html#extensions-for-loop-hint-optimizations
+
+#pragma clang loop unroll(enable)
+#pragma clang loop vectorize(enable)
+#elif defined __GNUG__
+    // Following
+    // https://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#Loop-Specific-Pragmas
+
+#pragma GCC ivdep
+#endif
+    for (size_t i = 0; i < wlen; i++) {
+      const size_t off = i * 4;
+
+      const auto word = bswap32(words[i]);
+      std::memcpy(bytes + off, &word, 4);
+    }
+  }
 }
 
 // Given a bytearray of length N, this function converts it to human readable

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -6,14 +6,17 @@
 #include <random>
 #include <sstream>
 
-consteval static inline bool is_little_endian() {
+consteval static inline bool
+is_little_endian()
+{
   return std::endian::native == std::endian::little;
 }
 
 // Given a bytearray of length N, this function converts it to human readable
 // hex string of length N << 1
-static inline const std::string to_hex(const uint8_t* const bytes,
-                                       const size_t len) {
+static inline const std::string
+to_hex(const uint8_t* const bytes, const size_t len)
+{
   std::stringstream ss;
   ss << std::hex;
 
@@ -25,8 +28,9 @@ static inline const std::string to_hex(const uint8_t* const bytes,
 }
 
 // Generates len (>=0) -many random elements of type T | T = unsigned integral
-template <typename T>
-static inline void random_data(T* const data, const size_t len)
+template<typename T>
+static inline void
+random_data(T* const data, const size_t len)
   requires(std::is_unsigned_v<T>)
 {
   std::random_device rd;

--- a/test_kat.sh
+++ b/test_kat.sh
@@ -50,4 +50,6 @@ rm LWC_*_KAT_*.txt
 
 popd
 
+make clean
+
 # ---

--- a/wrapper/esch.hpp
+++ b/wrapper/esch.hpp
@@ -7,27 +7,35 @@
 // used from other languages such as Rust, Python
 
 // Function prototype
-extern "C" {
-void esch256_hash(const uint8_t* const __restrict, const size_t,
-                  uint8_t* const __restrict);
+extern "C"
+{
+  void esch256_hash(const uint8_t* const __restrict,
+                    const size_t,
+                    uint8_t* const __restrict);
 
-void esch384_hash(const uint8_t* const __restrict, const size_t,
-                  uint8_t* const __restrict);
+  void esch384_hash(const uint8_t* const __restrict,
+                    const size_t,
+                    uint8_t* const __restrict);
 }
 
 // Function implementation
-extern "C" {
-// Given N (>=0) -bytes input message, this routines computes 32 -bytes output
-// digest, using Esch256 hash algorithm
-void esch256_hash(const uint8_t* const __restrict in, const size_t ilen,
-                  uint8_t* const __restrict out) {
-  esch256::hash(in, ilen, out);
-}
+extern "C"
+{
+  // Given N (>=0) -bytes input message, this routines computes 32 -bytes output
+  // digest, using Esch256 hash algorithm
+  void esch256_hash(const uint8_t* const __restrict in,
+                    const size_t ilen,
+                    uint8_t* const __restrict out)
+  {
+    esch256::hash(in, ilen, out);
+  }
 
-// Given N (>=0) -bytes input message, this routines computes 48 -bytes output
-// digest, using Esch384 hash algorithm
-void esch384_hash(const uint8_t* const __restrict in, const size_t ilen,
-                  uint8_t* const __restrict out) {
-  esch384::hash(in, ilen, out);
-}
+  // Given N (>=0) -bytes input message, this routines computes 48 -bytes output
+  // digest, using Esch384 hash algorithm
+  void esch384_hash(const uint8_t* const __restrict in,
+                    const size_t ilen,
+                    uint8_t* const __restrict out)
+  {
+    esch384::hash(in, ilen, out);
+  }
 }

--- a/wrapper/schwaemm.hpp
+++ b/wrapper/schwaemm.hpp
@@ -11,175 +11,217 @@
 // Python
 
 // Function prototype
-extern "C" {
-void schwaemm256_128_encrypt(const uint8_t* const __restrict,
-                             const uint8_t* const __restrict,
-                             const uint8_t* const __restrict, const size_t,
-                             const uint8_t* const __restrict,
-                             uint8_t* const __restrict, const size_t,
-                             uint8_t* const __restrict);
+extern "C"
+{
+  void schwaemm256_128_encrypt(const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const size_t,
+                               const uint8_t* const __restrict,
+                               uint8_t* const __restrict,
+                               const size_t,
+                               uint8_t* const __restrict);
 
-bool schwaemm256_128_decrypt(const uint8_t* const __restrict,
-                             const uint8_t* const __restrict,
-                             const uint8_t* const __restrict,
-                             const uint8_t* const __restrict, const size_t,
-                             const uint8_t* const __restrict,
-                             uint8_t* const __restrict, const size_t);
+  bool schwaemm256_128_decrypt(const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const size_t,
+                               const uint8_t* const __restrict,
+                               uint8_t* const __restrict,
+                               const size_t);
 
-void schwaemm192_192_encrypt(const uint8_t* const __restrict,
-                             const uint8_t* const __restrict,
-                             const uint8_t* const __restrict, const size_t,
-                             const uint8_t* const __restrict,
-                             uint8_t* const __restrict, const size_t,
-                             uint8_t* const __restrict);
+  void schwaemm192_192_encrypt(const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const size_t,
+                               const uint8_t* const __restrict,
+                               uint8_t* const __restrict,
+                               const size_t,
+                               uint8_t* const __restrict);
 
-bool schwaemm192_192_decrypt(const uint8_t* const __restrict,
-                             const uint8_t* const __restrict,
-                             const uint8_t* const __restrict,
-                             const uint8_t* const __restrict, const size_t,
-                             const uint8_t* const __restrict,
-                             uint8_t* const __restrict, const size_t);
+  bool schwaemm192_192_decrypt(const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const size_t,
+                               const uint8_t* const __restrict,
+                               uint8_t* const __restrict,
+                               const size_t);
 
-void schwaemm128_128_encrypt(const uint8_t* const __restrict,
-                             const uint8_t* const __restrict,
-                             const uint8_t* const __restrict, const size_t,
-                             const uint8_t* const __restrict,
-                             uint8_t* const __restrict, const size_t,
-                             uint8_t* const __restrict);
+  void schwaemm128_128_encrypt(const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const size_t,
+                               const uint8_t* const __restrict,
+                               uint8_t* const __restrict,
+                               const size_t,
+                               uint8_t* const __restrict);
 
-bool schwaemm128_128_decrypt(const uint8_t* const __restrict,
-                             const uint8_t* const __restrict,
-                             const uint8_t* const __restrict,
-                             const uint8_t* const __restrict, const size_t,
-                             const uint8_t* const __restrict,
-                             uint8_t* const __restrict, const size_t);
+  bool schwaemm128_128_decrypt(const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const size_t,
+                               const uint8_t* const __restrict,
+                               uint8_t* const __restrict,
+                               const size_t);
 
-void schwaemm256_256_encrypt(const uint8_t* const __restrict,
-                             const uint8_t* const __restrict,
-                             const uint8_t* const __restrict, const size_t,
-                             const uint8_t* const __restrict,
-                             uint8_t* const __restrict, const size_t,
-                             uint8_t* const __restrict);
+  void schwaemm256_256_encrypt(const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const size_t,
+                               const uint8_t* const __restrict,
+                               uint8_t* const __restrict,
+                               const size_t,
+                               uint8_t* const __restrict);
 
-bool schwaemm256_256_decrypt(const uint8_t* const __restrict,
-                             const uint8_t* const __restrict,
-                             const uint8_t* const __restrict,
-                             const uint8_t* const __restrict, const size_t,
-                             const uint8_t* const __restrict,
-                             uint8_t* const __restrict, const size_t);
+  bool schwaemm256_256_decrypt(const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const uint8_t* const __restrict,
+                               const size_t,
+                               const uint8_t* const __restrict,
+                               uint8_t* const __restrict,
+                               const size_t);
 }
 
-extern "C" {
+extern "C"
+{
 
-// Given 16 -bytes secret key, 32 -bytes nonce, N -bytes plain text & M -bytes
-// associated data, this routine computes N -bytes cipher text & 16 -bytes
-// authentication tag | N, M >= 0
-void schwaemm256_128_encrypt(const uint8_t* const __restrict key,
-                             const uint8_t* const __restrict nonce,
-                             const uint8_t* const __restrict data,
-                             const size_t d_len,
-                             const uint8_t* const __restrict txt,
-                             uint8_t* const __restrict enc, const size_t ct_len,
-                             uint8_t* const __restrict tag) {
-  schwaemm256_128::encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
-}
+  // Given 16 -bytes secret key, 32 -bytes nonce, N -bytes plain text & M -bytes
+  // associated data, this routine computes N -bytes cipher text & 16 -bytes
+  // authentication tag | N, M >= 0
+  void schwaemm256_128_encrypt(const uint8_t* const __restrict key,
+                               const uint8_t* const __restrict nonce,
+                               const uint8_t* const __restrict data,
+                               const size_t d_len,
+                               const uint8_t* const __restrict txt,
+                               uint8_t* const __restrict enc,
+                               const size_t ct_len,
+                               uint8_t* const __restrict tag)
+  {
+    schwaemm256_128::encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+  }
 
-// Given 16 -bytes secret key, 32 -bytes nonce, 16 -bytes authentication tag,
-// N -bytes cipher text & M -bytes associated data, this routine computes N
-// -bytes deciphered text & a boolean verification flag | N, M >= 0
-//
-// Before consuming decrypted bytes ensure presence of truth value in returned
-// boolean flag !
-bool schwaemm256_128_decrypt(
-    const uint8_t* const __restrict key, const uint8_t* const __restrict nonce,
-    const uint8_t* const __restrict tag, const uint8_t* const __restrict data,
-    const size_t d_len, const uint8_t* const __restrict enc,
-    uint8_t* const __restrict dec, const size_t ct_len) {
-  using namespace schwaemm256_128;
-  return decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
-}
+  // Given 16 -bytes secret key, 32 -bytes nonce, 16 -bytes authentication tag,
+  // N -bytes cipher text & M -bytes associated data, this routine computes N
+  // -bytes deciphered text & a boolean verification flag | N, M >= 0
+  //
+  // Before consuming decrypted bytes ensure presence of truth value in returned
+  // boolean flag !
+  bool schwaemm256_128_decrypt(const uint8_t* const __restrict key,
+                               const uint8_t* const __restrict nonce,
+                               const uint8_t* const __restrict tag,
+                               const uint8_t* const __restrict data,
+                               const size_t d_len,
+                               const uint8_t* const __restrict enc,
+                               uint8_t* const __restrict dec,
+                               const size_t ct_len)
+  {
+    using namespace schwaemm256_128;
+    return decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
+  }
 
-// Given 24 -bytes secret key, 24 -bytes nonce, N -bytes plain text & M -bytes
-// associated data, this routine computes N -bytes cipher text & 24 -bytes
-// authentication tag | N, M >= 0
-void schwaemm192_192_encrypt(const uint8_t* const __restrict key,
-                             const uint8_t* const __restrict nonce,
-                             const uint8_t* const __restrict data,
-                             const size_t d_len,
-                             const uint8_t* const __restrict txt,
-                             uint8_t* const __restrict enc, const size_t ct_len,
-                             uint8_t* const __restrict tag) {
-  schwaemm192_192::encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
-}
+  // Given 24 -bytes secret key, 24 -bytes nonce, N -bytes plain text & M -bytes
+  // associated data, this routine computes N -bytes cipher text & 24 -bytes
+  // authentication tag | N, M >= 0
+  void schwaemm192_192_encrypt(const uint8_t* const __restrict key,
+                               const uint8_t* const __restrict nonce,
+                               const uint8_t* const __restrict data,
+                               const size_t d_len,
+                               const uint8_t* const __restrict txt,
+                               uint8_t* const __restrict enc,
+                               const size_t ct_len,
+                               uint8_t* const __restrict tag)
+  {
+    schwaemm192_192::encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+  }
 
-// Given 24 -bytes secret key, 24 -bytes nonce, 24 -bytes authentication tag,
-// N -bytes cipher text & M -bytes associated data, this routine computes N
-// -bytes deciphered text & a boolean verification flag | N, M >= 0
-//
-// Before consuming decrypted bytes ensure presence of truth value in returned
-// boolean flag !
-bool schwaemm192_192_decrypt(
-    const uint8_t* const __restrict key, const uint8_t* const __restrict nonce,
-    const uint8_t* const __restrict tag, const uint8_t* const __restrict data,
-    const size_t d_len, const uint8_t* const __restrict enc,
-    uint8_t* const __restrict dec, const size_t ct_len) {
-  using namespace schwaemm192_192;
-  return decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
-}
+  // Given 24 -bytes secret key, 24 -bytes nonce, 24 -bytes authentication tag,
+  // N -bytes cipher text & M -bytes associated data, this routine computes N
+  // -bytes deciphered text & a boolean verification flag | N, M >= 0
+  //
+  // Before consuming decrypted bytes ensure presence of truth value in returned
+  // boolean flag !
+  bool schwaemm192_192_decrypt(const uint8_t* const __restrict key,
+                               const uint8_t* const __restrict nonce,
+                               const uint8_t* const __restrict tag,
+                               const uint8_t* const __restrict data,
+                               const size_t d_len,
+                               const uint8_t* const __restrict enc,
+                               uint8_t* const __restrict dec,
+                               const size_t ct_len)
+  {
+    using namespace schwaemm192_192;
+    return decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
+  }
 
-// Given 16 -bytes secret key, 16 -bytes nonce, N -bytes plain text & M -bytes
-// associated data, this routine computes N -bytes cipher text & 16 -bytes
-// authentication tag | N, M >= 0
-void schwaemm128_128_encrypt(const uint8_t* const __restrict key,
-                             const uint8_t* const __restrict nonce,
-                             const uint8_t* const __restrict data,
-                             const size_t d_len,
-                             const uint8_t* const __restrict txt,
-                             uint8_t* const __restrict enc, const size_t ct_len,
-                             uint8_t* const __restrict tag) {
-  schwaemm128_128::encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
-}
+  // Given 16 -bytes secret key, 16 -bytes nonce, N -bytes plain text & M -bytes
+  // associated data, this routine computes N -bytes cipher text & 16 -bytes
+  // authentication tag | N, M >= 0
+  void schwaemm128_128_encrypt(const uint8_t* const __restrict key,
+                               const uint8_t* const __restrict nonce,
+                               const uint8_t* const __restrict data,
+                               const size_t d_len,
+                               const uint8_t* const __restrict txt,
+                               uint8_t* const __restrict enc,
+                               const size_t ct_len,
+                               uint8_t* const __restrict tag)
+  {
+    schwaemm128_128::encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+  }
 
-// Given 16 -bytes secret key, 16 -bytes nonce, 16 -bytes authentication tag,
-// N -bytes cipher text & M -bytes associated data, this routine computes N
-// -bytes deciphered text & a boolean verification flag | N, M >= 0
-//
-// Before consuming decrypted bytes ensure presence of truth value in returned
-// boolean flag !
-bool schwaemm128_128_decrypt(
-    const uint8_t* const __restrict key, const uint8_t* const __restrict nonce,
-    const uint8_t* const __restrict tag, const uint8_t* const __restrict data,
-    const size_t d_len, const uint8_t* const __restrict enc,
-    uint8_t* const __restrict dec, const size_t ct_len) {
-  using namespace schwaemm128_128;
-  return decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
-}
+  // Given 16 -bytes secret key, 16 -bytes nonce, 16 -bytes authentication tag,
+  // N -bytes cipher text & M -bytes associated data, this routine computes N
+  // -bytes deciphered text & a boolean verification flag | N, M >= 0
+  //
+  // Before consuming decrypted bytes ensure presence of truth value in returned
+  // boolean flag !
+  bool schwaemm128_128_decrypt(const uint8_t* const __restrict key,
+                               const uint8_t* const __restrict nonce,
+                               const uint8_t* const __restrict tag,
+                               const uint8_t* const __restrict data,
+                               const size_t d_len,
+                               const uint8_t* const __restrict enc,
+                               uint8_t* const __restrict dec,
+                               const size_t ct_len)
+  {
+    using namespace schwaemm128_128;
+    return decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
+  }
 
-// Given 32 -bytes secret key, 32 -bytes nonce, N -bytes plain text & M -bytes
-// associated data, this routine computes N -bytes cipher text & 32 -bytes
-// authentication tag | N, M >= 0
-void schwaemm256_256_encrypt(const uint8_t* const __restrict key,
-                             const uint8_t* const __restrict nonce,
-                             const uint8_t* const __restrict data,
-                             const size_t d_len,
-                             const uint8_t* const __restrict txt,
-                             uint8_t* const __restrict enc, const size_t ct_len,
-                             uint8_t* const __restrict tag) {
-  schwaemm256_256::encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
-}
+  // Given 32 -bytes secret key, 32 -bytes nonce, N -bytes plain text & M -bytes
+  // associated data, this routine computes N -bytes cipher text & 32 -bytes
+  // authentication tag | N, M >= 0
+  void schwaemm256_256_encrypt(const uint8_t* const __restrict key,
+                               const uint8_t* const __restrict nonce,
+                               const uint8_t* const __restrict data,
+                               const size_t d_len,
+                               const uint8_t* const __restrict txt,
+                               uint8_t* const __restrict enc,
+                               const size_t ct_len,
+                               uint8_t* const __restrict tag)
+  {
+    schwaemm256_256::encrypt(key, nonce, data, d_len, txt, enc, ct_len, tag);
+  }
 
-// Given 32 -bytes secret key, 32 -bytes nonce, 32 -bytes authentication tag,
-// N -bytes cipher text & M -bytes associated data, this routine computes N
-// -bytes deciphered text & a boolean verification flag | N, M >= 0
-//
-// Before consuming decrypted bytes ensure presence of truth value in returned
-// boolean flag !
-bool schwaemm256_256_decrypt(
-    const uint8_t* const __restrict key, const uint8_t* const __restrict nonce,
-    const uint8_t* const __restrict tag, const uint8_t* const __restrict data,
-    const size_t d_len, const uint8_t* const __restrict enc,
-    uint8_t* const __restrict dec, const size_t ct_len) {
-  using namespace schwaemm256_256;
-  return decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
-}
+  // Given 32 -bytes secret key, 32 -bytes nonce, 32 -bytes authentication tag,
+  // N -bytes cipher text & M -bytes associated data, this routine computes N
+  // -bytes deciphered text & a boolean verification flag | N, M >= 0
+  //
+  // Before consuming decrypted bytes ensure presence of truth value in returned
+  // boolean flag !
+  bool schwaemm256_256_decrypt(const uint8_t* const __restrict key,
+                               const uint8_t* const __restrict nonce,
+                               const uint8_t* const __restrict tag,
+                               const uint8_t* const __restrict data,
+                               const size_t d_len,
+                               const uint8_t* const __restrict enc,
+                               uint8_t* const __restrict dec,
+                               const size_t ct_len)
+  {
+    using namespace schwaemm256_256;
+    return decrypt(key, nonce, tag, data, d_len, enc, dec, ct_len);
+  }
 }


### PR DESCRIPTION
Refactor Sparkle Cipher Suite i.e. Esch hash functions and Schwaemm AEAD routines so that it becomes easier to use/ test/ benchmark API, while also performance of this implementation improves. 